### PR TITLE
 Truncate test failures if too large

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-model</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Autograding Model</name>
 
   <description>This module autogrades Java projects based on a configurable set of metrics.</description>

--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -51,13 +51,6 @@ public class AnalysisMarkdown extends ScoreMarkdown {
                 String.valueOf(analysisScore.getLowSeveritySize()),
                 String.valueOf(analysisScore.getTotalImpact())})));
 
-        if (score.hasWarnings()) {
-            stringBuilder.append("### Warnings\n");
-            analysisReports.stream()
-                    .flatMap(Report::stream).limit(20)
-                    .forEach(issue -> stringBuilder.append("- ").append(issue).append("\n"));
-        }
-
         return stringBuilder.toString();
     }
 

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -13,6 +13,8 @@ import edu.hm.hafner.analysis.Report;
  */
 public class TestMarkdown extends ScoreMarkdown {
     static final String TYPE = "Unit Tests Score";
+    static final int MAX_LENGTH_DETAILS = 65535 - 500;
+    static final String TRUNCATED_MESSAGE = "\\[.. truncated ..\\]";
 
     /**
      * Creates a new Markdown renderer for static analysis results.
@@ -52,11 +54,21 @@ public class TestMarkdown extends ScoreMarkdown {
 
         if (score.hasTestFailures()) {
             stringBuilder.append("### Failures\n");
-            testReports.stream().flatMap(Report::stream).forEach(issue -> stringBuilder.append(renderFailure(issue)));
+            testReports.stream().flatMap(Report::stream).forEach(issue -> appendReasonForFailure(stringBuilder, issue));
             stringBuilder.append("\n");
         }
 
         return stringBuilder.toString();
+    }
+
+    private void appendReasonForFailure(final StringBuilder stringBuilder, final Issue issue) {
+        String nextFailure = renderFailure(issue);
+        if (stringBuilder.length() + nextFailure.length() < MAX_LENGTH_DETAILS) {
+            stringBuilder.append(nextFailure);
+        }
+        else if (!stringBuilder.toString().endsWith(TRUNCATED_MESSAGE)) {
+            stringBuilder.append(TRUNCATED_MESSAGE);
+        }
     }
 
     private String renderFailure(final Issue issue) {

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -1,8 +1,12 @@
 package edu.hm.hafner.grading;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -30,5 +34,41 @@ class GradingReportTest {
                 .contains("Code Coverage Score not enabled")
                 .contains("PIT Mutation Coverage Score not enabled")
                 .contains("Static Analysis Warnings Score");
+    }
+
+    @Test
+    void shouldTruncateResults() {
+        GradingReport results = new GradingReport();
+
+        AggregatedScore score = new AggregatedScore("{\"tests\": {\n"
+                + "    \"maxScore\": 100,\n"
+                + "    \"passedImpact\": 0,\n"
+                + "    \"failureImpact\": -5,\n"
+                + "    \"skippedImpact\": -1\n"
+                + "  }}");
+        Report report = new Report();
+        for (int i = 0; i < 60000; i++) {
+            report.add(new IssueBuilder().setFileName(String.valueOf(i)).build());
+        }
+
+        score.addTestScores(new TestSupplier() {
+            @Override
+            protected List<TestScore> createScores(final TestConfiguration configuration) {
+                return Collections.singletonList(createFirstScore(configuration));
+            }
+        });
+        assertThat(results.getDetails(score, Collections.singletonList(report), Collections.emptyList()))
+                .contains(TestMarkdown.TRUNCATED_MESSAGE)
+                .hasSizeLessThan(65535);
+    }
+
+    private TestScore createFirstScore(final TestConfiguration configuration) {
+        return new TestScore.TestScoreBuilder()
+                .withDisplayName("First")
+                .withConfiguration(configuration)
+                .withFailedSize(1)
+                .withSkippedSize(2)
+                .withTotalSize(6)
+                .build();
     }
 }


### PR DESCRIPTION
Since GitHub shows at least 65535 characters in the checks text we need to skip test failures. 