### PR TITLE
Add a new property to specify the source path prefix for a tool

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisConfiguration.java
@@ -7,7 +7,8 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
- * Configuration to grade static analysis results.
+ * Configuration to grade static analysis results. The configuration specifies the impact of the static analysis results
+ * on the score. This class is intended to be deserialized from JSON, there is no public constructor available.
  *
  * @author Ullrich Hafner
  */
@@ -48,7 +49,8 @@ public final class AnalysisConfiguration extends Configuration {
         return "Static Analysis Warnings";
     }
 
-    @Override @JsonIgnore
+    @Override
+    @JsonIgnore
     public boolean isPositive() {
         return errorImpact >= 0 && highImpact >= 0 && normalImpact >= 0 && lowImpact >= 0;
     }

--- a/src/main/java/edu/hm/hafner/grading/CoverageConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageConfiguration.java
@@ -8,7 +8,8 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
- * Configuration to grade code coverage results.
+ * Configuration to grade code coverage results. The configuration specifies the impact of the coverage results on the
+ * score. This class is intended to be deserialized from JSON, there is no public constructor available.
  *
  * @author Ullrich Hafner
  */

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -126,7 +126,7 @@ public class GradingReport {
      */
     public String getMarkdownErrors(final AggregatedScore score, final Throwable exception) {
         return String.format(
-                "# Partial score: %s/%s%n:construction: The grading has been aborted due to an error.:construction:%n",
+                "# Partial score: %s/%s%n:construction: The grading has been aborted due to an error.%n",
                 score.getAchievedScore(), score.getMaxScore())
                 + createExceptionSection(exception)
                 + createLogSection(score);

--- a/src/main/java/edu/hm/hafner/grading/TestConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/TestConfiguration.java
@@ -7,7 +7,8 @@ import java.util.Objects;
 import edu.hm.hafner.util.Generated;
 
 /**
- * Configuration to grade test results.
+ * Configuration to grade test results. The configuration specifies the impact of the test results on the score. This
+ * class is intended to be deserialized from JSON, there is no public constructor available.
  *
  * @author Ullrich Hafner
  */
@@ -63,7 +64,8 @@ public final class TestConfiguration extends Configuration {
         return passedImpact;
     }
 
-    @Override @Generated
+    @Override
+    @Generated
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -80,7 +82,8 @@ public final class TestConfiguration extends Configuration {
                 && skippedImpact == that.skippedImpact;
     }
 
-    @Override @Generated
+    @Override
+    @Generated
     public int hashCode() {
         return Objects.hash(super.hashCode(), failureImpact, passedImpact, skippedImpact);
     }

--- a/src/main/java/edu/hm/hafner/grading/ToolConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/ToolConfiguration.java
@@ -7,7 +7,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * A tool configuration provides an identifier and report pattern for a specific development tool.
+ * A tool configuration provides an identifier and report pattern for a specific development tool. This class is
+ * intended to be deserialized from JSON, there is no public constructor available.
  *
  * @author Ullrich Hafner
  */
@@ -20,22 +21,25 @@ public final class ToolConfiguration implements Serializable {
     private final String id;
     private final String name;
     private final String pattern;
+    private final String sourcePath;
     private final String metric;
 
     @SuppressWarnings("unused") // Required for JSON conversion
-    ToolConfiguration() {
-        this(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY);
+    private ToolConfiguration() {
+        this(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY);
     }
 
-    public ToolConfiguration(final String id, final String name, final String pattern) {
-        this(id, name, pattern, StringUtils.EMPTY);
+    ToolConfiguration(final String id, final String name, final String pattern, final String sourcePath) {
+        this(id, name, pattern, sourcePath, StringUtils.EMPTY);
     }
 
-    public ToolConfiguration(final String id, final String name, final String pattern, final String metric) {
+    ToolConfiguration(final String id, final String name, final String pattern, final String sourcePath,
+            final String metric) {
         this.id = id;
         this.name = name;
         this.pattern = pattern;
         this.metric = metric;
+        this.sourcePath = sourcePath;
     }
 
     public String getId() {
@@ -52,6 +56,10 @@ public final class ToolConfiguration implements Serializable {
 
     public String getPattern() {
         return StringUtils.defaultString(pattern);
+    }
+
+    public String getSourcePath() {
+        return StringUtils.defaultString(sourcePath);
     }
 
     public String getMetric() {
@@ -78,6 +86,9 @@ public final class ToolConfiguration implements Serializable {
         if (!Objects.equals(pattern, that.pattern)) {
             return false;
         }
+        if (!Objects.equals(sourcePath, that.sourcePath)) {
+            return false;
+        }
         return Objects.equals(metric, that.metric);
     }
 
@@ -86,6 +97,7 @@ public final class ToolConfiguration implements Serializable {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
+        result = 31 * result + (sourcePath != null ? sourcePath.hashCode() : 0);
         result = 31 * result + (metric != null ? metric.hashCode() : 0);
         return result;
     }

--- a/src/test/java/edu/hm/hafner/grading/AnalysisConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisConfigurationTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -38,8 +39,8 @@ class AnalysisConfigurationTest {
                 .hasMaxScore(50)
                 .hasName("Checkstyle and SpotBugs")
                 .isPositive()
-                .hasOnlyTools(new ToolConfiguration("checkstyle", "", "target/checkstyle.xml"),
-                        new ToolConfiguration("spotbugs", "", "target/spotbugsXml.xml")));
+                .hasOnlyTools(new ToolConfiguration("checkstyle", "", "target/checkstyle.xml", StringUtils.EMPTY),
+                        new ToolConfiguration("spotbugs", "", "target/spotbugsXml.xml", StringUtils.EMPTY)));
     }
 
     @Test
@@ -125,8 +126,9 @@ class AnalysisConfigurationTest {
                 .hasLowImpact(4)
                 .hasMaxScore(5)
                 .isPositive()
-                .hasOnlyTools(new ToolConfiguration("checkstyle", "Checkstyle", "target/checkstyle.xml"),
-                        new ToolConfiguration("spotbugs", "SpotBugs", "target/spotbugsXml.xml"));
+                .hasOnlyTools(new ToolConfiguration("checkstyle", "Checkstyle", "target/checkstyle.xml",
+                                StringUtils.EMPTY),
+                        new ToolConfiguration("spotbugs", "SpotBugs", "target/spotbugsXml.xml", StringUtils.EMPTY));
     }
 
     private void verifyLastConfiguration(final AnalysisConfiguration configuration) {
@@ -137,7 +139,7 @@ class AnalysisConfigurationTest {
                 .hasLowImpact(-14)
                 .hasMaxScore(-15)
                 .isNotPositive()
-                .hasOnlyTools(new ToolConfiguration("pmd", "PMD", "target/pmd.xml"));
+                .hasOnlyTools(new ToolConfiguration("pmd", "PMD", "target/pmd.xml", StringUtils.EMPTY));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/CoverageConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageConfigurationTest.java
@@ -42,8 +42,8 @@ class CoverageConfigurationTest {
                 .hasMaxScore(50)
                 .hasName("JaCoCo and PIT")
                 .isPositive()
-                .hasOnlyTools(new ToolConfiguration("jacoco", "", "target/jacoco.xml", getMetricName(Metric.LINE)),
-                        new ToolConfiguration("pit", "", "target/pit.xml", getMetricName(Metric.MUTATION))));
+                .hasOnlyTools(new ToolConfiguration("jacoco", "", "target/jacoco.xml", "", getMetricName(Metric.LINE)),
+                        new ToolConfiguration("pit", "", "target/pit.xml", "", getMetricName(Metric.MUTATION))));
     }
 
     @Test
@@ -121,8 +121,8 @@ class CoverageConfigurationTest {
                 .hasMissedPercentageImpact(2)
                 .hasMaxScore(50)
                 .isPositive()
-                .hasOnlyTools(new ToolConfiguration("jacoco", "", "target/jacoco.xml", getMetricName(Metric.LINE)),
-                        new ToolConfiguration("pit", "", "target/pit.xml", getMetricName(Metric.MUTATION)));
+                .hasOnlyTools(new ToolConfiguration("jacoco", "", "target/jacoco.xml", "", getMetricName(Metric.LINE)),
+                        new ToolConfiguration("pit", "", "target/pit.xml", "", getMetricName(Metric.MUTATION)));
     }
 
     private String getMetricName(final Metric metric) {
@@ -136,7 +136,7 @@ class CoverageConfigurationTest {
                 .hasMaxScore(100)
                 .isNotPositive()
                 .hasOnlyTools(new ToolConfiguration("cobertura", "", "target/cobertura.xml",
-                        getMetricName(Metric.BRANCH)));
+                        "", getMetricName(Metric.BRANCH)));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/TestConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestConfigurationTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -35,7 +36,7 @@ class TestConfigurationTest {
                 .hasMaxScore(50)
                 .hasName("Unit Tests")
                 .isNotPositive()
-                .hasOnlyTools(new ToolConfiguration("junit", "", "target/junit.xml")));
+                .hasOnlyTools(new ToolConfiguration("junit", "", "target/junit.xml", StringUtils.EMPTY)));
     }
 
     @Test
@@ -118,8 +119,8 @@ class TestConfigurationTest {
                 .hasSkippedImpact(1)
                 .hasMaxScore(50)
                 .isPositive()
-                .hasOnlyTools(new ToolConfiguration("junit", "Junit tests", "target/junit.xml"),
-                        new ToolConfiguration("jest", "JEST", "target/jest.xml"));
+                .hasOnlyTools(new ToolConfiguration("junit", "Junit tests", "target/junit.xml", StringUtils.EMPTY),
+                        new ToolConfiguration("jest", "JEST", "target/jest.xml", StringUtils.EMPTY));
     }
 
     private void verifyLastConfiguration(final TestConfiguration configuration) {
@@ -129,7 +130,7 @@ class TestConfigurationTest {
                 .hasSkippedImpact(-1)
                 .hasMaxScore(500)
                 .isNotPositive()
-                .hasOnlyTools(new ToolConfiguration("junit", "", "target/junit.xml"));
+                .hasOnlyTools(new ToolConfiguration("junit", "", "target/junit.xml", StringUtils.EMPTY));
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/ToolConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ToolConfigurationTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -9,7 +10,8 @@ import static edu.hm.hafner.grading.assertions.Assertions.*;
 class ToolConfigurationTest {
     @Test
     void shouldCreateTool() {
-        var toolConfiguration = new ToolConfiguration("spotbugs", "SpotBugs", "target/spotbugsXml.xml");
+        var toolConfiguration = new ToolConfiguration("spotbugs", "SpotBugs", "target/spotbugsXml.xml",
+                StringUtils.EMPTY);
 
         assertThat(toolConfiguration).hasId("spotbugs").hasName("SpotBugs").hasPattern("target/spotbugsXml.xml");
     }


### PR DESCRIPTION
JaCoCo reports sources starting with the package name directories. We need to find a way to set the `src/main/java` folder as a prefix.