### PR TITLE
Move comments creation to the model

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -66,8 +66,8 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
      *
      * @return this
      */
-    @CanIgnoreReturnValue
-    private AnalysisScore readResolve() {
+    @Serial @CanIgnoreReturnValue
+    private Object readResolve() {
         report = new Report();
 
         return this;
@@ -245,12 +245,10 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
             Ensure.that(report != null ^ !scores.isEmpty()).isTrue(
                     "You must either specify an analysis report or provide a list of sub-scores.");
 
-            if (scores.isEmpty() && report != null) {
-                return new AnalysisScore(getId(), getName(), getConfiguration(), report);
-            }
-            else {
+            if (report == null) {
                 return new AnalysisScore(getId(), getName(), getConfiguration(), scores);
             }
+            return new AnalysisScore(getId(), getName(), getConfiguration(), Objects.requireNonNull(report));
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -33,8 +33,7 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
     private final int normalSeveritySize;
     private final int lowSeveritySize;
 
-    @CheckForNull
-    private final transient Report report; // do not persist the issues
+    private transient Report report; // do not persist the issues
 
     private AnalysisScore(final String id, final String name, final AnalysisConfiguration configuration,
             final List<AnalysisScore> scores) {
@@ -60,6 +59,18 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
         this.lowSeveritySize = report.getSizeOf(Severity.WARNING_LOW);
 
         this.report = report;
+    }
+
+    /**
+     * Restore an empty report after de-serialization.
+     *
+     * @return this
+     */
+    @CanIgnoreReturnValue
+    private AnalysisScore readResolve() {
+        report = new Report();
+
+        return this;
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -41,8 +41,10 @@ public class AutoGradingRunner {
 
     /**
      * Runs the autograding.
+     *
+     * @return the grading score
      */
-    public void run() {
+    public AggregatedScore run() {
         var log = new FilteredLog("Autograding GitHub Action Errors:");
 
         var logHandler = new LogHandler(outputStream, log);
@@ -89,6 +91,8 @@ public class AutoGradingRunner {
             publishError(score, log, exception);
         }
         logHandler.print();
+
+        return score;
     }
 
     private void logEndOfGrading(final FilteredLog log) {

--- a/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
@@ -2,6 +2,7 @@ package edu.hm.hafner.grading;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
@@ -16,6 +17,7 @@ import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Mutation;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.LineRange;
+import edu.hm.hafner.util.PathUtil;
 
 /**
  * Creates comments for static analysis warnings, for lines with missing coverage, and for lines with survived
@@ -24,24 +26,27 @@ import edu.hm.hafner.util.LineRange;
  * @author Ullrich Hafner
  */
 public abstract class CommentBuilder {
-    private static final String GITHUB_WORKSPACE_REL = "/github/workspace/./";
-    private static final String GITHUB_WORKSPACE_ABS = "/github/workspace/";
     private static final int NO_COLUMN = -1;
     private static final String NO_ADDITIONAL_DETAILS = StringUtils.EMPTY;
+    private static final PathUtil PATH_UTIL = new PathUtil();
+
+    private final List<String> prefixes;
+
+    protected CommentBuilder(final String... prefixesToRemove) {
+        prefixes = Arrays.asList(prefixesToRemove);
+    }
 
     void createAnnotations(final AggregatedScore score, final FilteredLog log) {
         if (getEnv("SKIP_ANNOTATIONS", log).isEmpty()) {
-            var prefix = computeAbsolutePathPrefixToRemove(log);
-
             var additionalAnalysisSourcePaths = extractAdditionalSourcePaths(score.getAnalysisScores());
-            createAnnotationsForIssues(score, prefix, additionalAnalysisSourcePaths);
+            createAnnotationsForIssues(score, additionalAnalysisSourcePaths);
 
             var additionalCoverageSourcePaths = extractAdditionalSourcePaths(score.getCodeCoverageScores());
-            createAnnotationsForMissedLines(score, prefix, additionalCoverageSourcePaths);
-            createAnnotationsForPartiallyCoveredLines(score, prefix, additionalCoverageSourcePaths);
+            createAnnotationsForMissedLines(score, additionalCoverageSourcePaths);
+            createAnnotationsForPartiallyCoveredLines(score, additionalCoverageSourcePaths);
 
             var additionalMutationSourcePaths = extractAdditionalSourcePaths(score.getMutationCoverageScores());
-            createAnnotationsForSurvivedMutations(score, prefix, additionalMutationSourcePaths);
+            createAnnotationsForSurvivedMutations(score, additionalMutationSourcePaths);
         }
     }
 
@@ -72,11 +77,6 @@ public abstract class CommentBuilder {
             int columnStart, int columnEnd,
             String details);
 
-    private String computeAbsolutePathPrefixToRemove(final FilteredLog log) {
-        return String.format("%s/%s/", getEnv("RUNNER_WORKSPACE", log),
-                StringUtils.substringAfter(getEnv("GITHUB_REPOSITORY", log), "/"));
-    }
-
     private Set<String> extractAdditionalSourcePaths(final List<? extends Score<?, ?>> scores) {
         return scores.stream()
                 .map(Score::getConfiguration)
@@ -86,35 +86,40 @@ public abstract class CommentBuilder {
     }
 
     private void createAnnotationsForIssues(final AggregatedScore score,
-            final String prefix, final Set<String> sourcePaths) {
-        score.getIssues().forEach(issue -> createAnnotationForIssue(issue, prefix, sourcePaths));
+            final Set<String> sourcePaths) {
+        score.getIssues().forEach(issue -> createAnnotationForIssue(issue, sourcePaths));
     }
 
     private void createAnnotationForIssue(final Issue issue,
-            final String prefix, final Set<String> sourcePaths) {
-        var path = createRelativeRepositoryPath(issue.getFileName(), prefix, sourcePaths);
-        var relativePath = StringUtils.removeStart(
-                StringUtils.removeStart(path, GITHUB_WORKSPACE_REL), GITHUB_WORKSPACE_ABS);
+            final Set<String> sourcePaths) {
+        var relativePath = cleanPath(createRelativeRepositoryPath(issue.getFileName(), sourcePaths));
 
         createComment(relativePath, issue.getLineStart(), issue.getLineEnd(), issue.getMessage(),
                 issue.getOriginName() + ": " + issue.getType(), issue.getColumnStart(), issue.getColumnEnd(),
                 NO_ADDITIONAL_DETAILS);
     }
 
-    private void createAnnotationsForMissedLines(final AggregatedScore score,
-            final String prefix, final Set<String> sourcePaths) {
-        score.getCoveredFiles(Metric.LINE).forEach(file -> createAnnotationsForMissedLines(file, prefix, sourcePaths));
+    private String cleanPath(final String path) {
+        for (String prefix : prefixes) {
+            if (path.startsWith(prefix)) {
+                return StringUtils.removeStart(path, prefix);
+            }
+        }
+        return path;
     }
 
-    private void createAnnotationsForMissedLines(final FileNode file,
-            final String prefix, final Set<String> sourcePaths) {
+    private void createAnnotationsForMissedLines(final AggregatedScore score, final Set<String> sourcePaths) {
+        score.getCoveredFiles(Metric.LINE).forEach(file -> createAnnotationsForMissedLines(file, sourcePaths));
+    }
+
+    private void createAnnotationsForMissedLines(final FileNode file, final Set<String> sourcePaths) {
         file.getMissedLineRanges()
-                .forEach(range -> createAnnotationForMissedLineRange(file, range, prefix, sourcePaths));
+                .forEach(range -> createAnnotationForMissedLineRange(file, range, sourcePaths));
     }
 
     private void createAnnotationForMissedLineRange(final FileNode file, final LineRange range,
-            final String prefix, final Set<String> sourcePaths) {
-        var relativePath = createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths);
+            final Set<String> sourcePaths) {
+        var relativePath = createRelativeRepositoryPath(file.getRelativePath(), sourcePaths);
 
         createComment(relativePath,
                 range.getStart(), range.getEnd(),
@@ -138,21 +143,21 @@ public abstract class CommentBuilder {
     }
 
     private void createAnnotationsForPartiallyCoveredLines(final AggregatedScore score,
-            final String prefix, final Set<String> sourcePaths) {
+            final Set<String> sourcePaths) {
         score.getCoveredFiles(Metric.BRANCH)
-                .forEach(file -> createAnnotationsForMissedBranches(file, prefix, sourcePaths));
+                .forEach(file -> createAnnotationsForMissedBranches(file, sourcePaths));
     }
 
     private void createAnnotationsForMissedBranches(final FileNode file,
-            final String prefix, final Set<String> sourcePaths) {
+            final Set<String> sourcePaths) {
         file.getPartiallyCoveredLines().entrySet()
-                .forEach(entry -> createAnnotationForMissedBranches(file, entry, prefix, sourcePaths));
+                .forEach(entry -> createAnnotationForMissedBranches(file, entry, sourcePaths));
     }
 
     private void createAnnotationForMissedBranches(final FileNode file,
             final Entry<Integer, Integer> branchCoverage,
-            final String prefix, final Set<String> sourcePaths) {
-        createComment(createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths),
+            final Set<String> sourcePaths) {
+        createComment(createRelativeRepositoryPath(file.getRelativePath(), sourcePaths),
                 branchCoverage.getKey(), branchCoverage.getKey(),
                 createBranchMessage(branchCoverage.getKey(), branchCoverage.getValue()), "Partially covered line",
                 NO_COLUMN, NO_COLUMN, NO_ADDITIONAL_DETAILS);
@@ -165,14 +170,13 @@ public abstract class CommentBuilder {
         return String.format("Line %d is only partially covered, %d branches are missing", line, missed);
     }
 
-    private String createRelativeRepositoryPath(final String fileName,
-            final String prefix, final Set<String> sourcePaths) {
-        var cleaned = StringUtils.removeStart(fileName, prefix);
+    private String createRelativeRepositoryPath(final String fileName, final Set<String> sourcePaths) {
+        var cleaned = cleanPath(fileName);
         if (Files.exists(Path.of(cleaned))) {
             return cleaned;
         }
         for (String s : sourcePaths) {
-            var added = s + "/" + cleaned;
+            var added = PATH_UTIL.createAbsolutePath(s, cleaned);
             if (Files.exists(Path.of(added))) {
                 return added;
             }
@@ -181,21 +185,21 @@ public abstract class CommentBuilder {
     }
 
     private void createAnnotationsForSurvivedMutations(final AggregatedScore score,
-            final String prefix, final Set<String> sourcePaths) {
+            final Set<String> sourcePaths) {
         score.getCoveredFiles(Metric.MUTATION)
-                .forEach(file -> createAnnotationsForSurvivedMutations(file, prefix, sourcePaths));
+                .forEach(file -> createAnnotationsForSurvivedMutations(file, sourcePaths));
     }
 
     private void createAnnotationsForSurvivedMutations(final FileNode file,
-            final String prefix, final Set<String> sourcePaths) {
+            final Set<String> sourcePaths) {
         file.getSurvivedMutationsPerLine().entrySet()
-                .forEach(entry -> createAnnotationForSurvivedMutation(file, entry, prefix, sourcePaths));
+                .forEach(entry -> createAnnotationForSurvivedMutation(file, entry, sourcePaths));
     }
 
     private void createAnnotationForSurvivedMutation(final FileNode file,
             final Entry<Integer, List<Mutation>> mutationsPerLine,
-            final String prefix, final Set<String> sourcePaths) {
-        createComment(createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths),
+            final Set<String> sourcePaths) {
+        createComment(createRelativeRepositoryPath(file.getRelativePath(), sourcePaths),
                 mutationsPerLine.getKey(), mutationsPerLine.getKey(),
                 createMutationMessage(mutationsPerLine.getKey(), mutationsPerLine.getValue()), "Mutation survived",
                 NO_COLUMN, NO_COLUMN, createMutationDetails(mutationsPerLine.getValue()));

--- a/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
@@ -1,0 +1,226 @@
+package edu.hm.hafner.grading;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.coverage.FileNode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.Mutation;
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.LineRange;
+
+/**
+ * Creates comments for static analysis warnings, for lines with missing coverage, and for lines with survived
+ * mutations.
+ *
+ * @author Ullrich Hafner
+ */
+public abstract class CommentBuilder {
+    private static final String GITHUB_WORKSPACE_REL = "/github/workspace/./";
+    private static final String GITHUB_WORKSPACE_ABS = "/github/workspace/";
+    private static final int NO_COLUMN = -1;
+    private static final String NO_ADDITIONAL_DETAILS = StringUtils.EMPTY;
+
+    void createAnnotations(final AggregatedScore score, final FilteredLog log) {
+        if (getEnv("SKIP_ANNOTATIONS", log).isEmpty()) {
+            var prefix = computeAbsolutePathPrefixToRemove(log);
+
+            var additionalAnalysisSourcePaths = extractAdditionalSourcePaths(score.getAnalysisScores());
+            createAnnotationsForIssues(score, prefix, additionalAnalysisSourcePaths);
+
+            var additionalCoverageSourcePaths = extractAdditionalSourcePaths(score.getCodeCoverageScores());
+            createAnnotationsForMissedLines(score, prefix, additionalCoverageSourcePaths);
+            createAnnotationsForPartiallyCoveredLines(score, prefix, additionalCoverageSourcePaths);
+
+            var additionalMutationSourcePaths = extractAdditionalSourcePaths(score.getMutationCoverageScores());
+            createAnnotationsForSurvivedMutations(score, prefix, additionalMutationSourcePaths);
+        }
+    }
+
+    /**
+     * Creates a new comment.
+     *
+     * @param relativePath
+     *         relative path of the file in the Git repository
+     * @param lineStart
+     *         start line of the comment
+     * @param lineEnd
+     *         end line of the comment
+     * @param message
+     *         message of the comment
+     * @param title
+     *         title of the comment
+     * @param columnStart
+     *         column of the comment (-1 if not applicable)
+     * @param columnEnd
+     *         column of the comment (-1 if not applicable)
+     * @param details
+     *         additional details of the comment (empty if not applicable)
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    protected abstract void createComment(String relativePath,
+            int lineStart, int lineEnd,
+            String message, String title,
+            int columnStart, int columnEnd,
+            String details);
+
+    private String computeAbsolutePathPrefixToRemove(final FilteredLog log) {
+        return String.format("%s/%s/", getEnv("RUNNER_WORKSPACE", log),
+                StringUtils.substringAfter(getEnv("GITHUB_REPOSITORY", log), "/"));
+    }
+
+    private Set<String> extractAdditionalSourcePaths(final List<? extends Score<?, ?>> scores) {
+        return scores.stream()
+                .map(Score::getConfiguration)
+                .map(Configuration::getTools)
+                .flatMap(Collection::stream)
+                .map(ToolConfiguration::getSourcePath).collect(Collectors.toSet());
+    }
+
+    private void createAnnotationsForIssues(final AggregatedScore score,
+            final String prefix, final Set<String> sourcePaths) {
+        score.getIssues().forEach(issue -> createAnnotationForIssue(issue, prefix, sourcePaths));
+    }
+
+    private void createAnnotationForIssue(final Issue issue,
+            final String prefix, final Set<String> sourcePaths) {
+        var path = createRelativeRepositoryPath(issue.getFileName(), prefix, sourcePaths);
+        var relativePath = StringUtils.removeStart(
+                StringUtils.removeStart(path, GITHUB_WORKSPACE_REL), GITHUB_WORKSPACE_ABS);
+
+        createComment(relativePath, issue.getLineStart(), issue.getLineEnd(), issue.getMessage(),
+                issue.getOriginName() + ": " + issue.getType(), issue.getColumnStart(), issue.getColumnEnd(),
+                NO_ADDITIONAL_DETAILS);
+    }
+
+    private void createAnnotationsForMissedLines(final AggregatedScore score,
+            final String prefix, final Set<String> sourcePaths) {
+        score.getCoveredFiles(Metric.LINE).forEach(file -> createAnnotationsForMissedLines(file, prefix, sourcePaths));
+    }
+
+    private void createAnnotationsForMissedLines(final FileNode file,
+            final String prefix, final Set<String> sourcePaths) {
+        file.getMissedLineRanges()
+                .forEach(range -> createAnnotationForMissedLineRange(file, range, prefix, sourcePaths));
+    }
+
+    private void createAnnotationForMissedLineRange(final FileNode file, final LineRange range,
+            final String prefix, final Set<String> sourcePaths) {
+        var relativePath = createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths);
+
+        createComment(relativePath,
+                range.getStart(), range.getEnd(),
+                getMissedLinesDescription(range), getMissedLinesMessage(range),
+                NO_COLUMN, NO_COLUMN,
+                NO_ADDITIONAL_DETAILS);
+    }
+
+    private String getMissedLinesMessage(final LineRange range) {
+        if (range.getStart() == range.getEnd()) {
+            return "Not covered line";
+        }
+        return "Not covered lines";
+    }
+
+    private String getMissedLinesDescription(final LineRange range) {
+        if (range.getStart() == range.getEnd()) {
+            return String.format("Line %d is not covered by tests", range.getStart());
+        }
+        return String.format("Lines %d-%d are not covered by tests", range.getStart(), range.getEnd());
+    }
+
+    private void createAnnotationsForPartiallyCoveredLines(final AggregatedScore score,
+            final String prefix, final Set<String> sourcePaths) {
+        score.getCoveredFiles(Metric.BRANCH)
+                .forEach(file -> createAnnotationsForMissedBranches(file, prefix, sourcePaths));
+    }
+
+    private void createAnnotationsForMissedBranches(final FileNode file,
+            final String prefix, final Set<String> sourcePaths) {
+        file.getPartiallyCoveredLines().entrySet()
+                .forEach(entry -> createAnnotationForMissedBranches(file, entry, prefix, sourcePaths));
+    }
+
+    private void createAnnotationForMissedBranches(final FileNode file,
+            final Entry<Integer, Integer> branchCoverage,
+            final String prefix, final Set<String> sourcePaths) {
+        createComment(createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths),
+                branchCoverage.getKey(), branchCoverage.getKey(),
+                createBranchMessage(branchCoverage.getKey(), branchCoverage.getValue()), "Partially covered line",
+                NO_COLUMN, NO_COLUMN, NO_ADDITIONAL_DETAILS);
+    }
+
+    private String createBranchMessage(final int line, final int missed) {
+        if (missed == 1) {
+            return String.format("Line %d is only partially covered, one branch is missing", line);
+        }
+        return String.format("Line %d is only partially covered, %d branches are missing", line, missed);
+    }
+
+    private String createRelativeRepositoryPath(final String fileName,
+            final String prefix, final Set<String> sourcePaths) {
+        var cleaned = StringUtils.removeStart(fileName, prefix);
+        if (Files.exists(Path.of(cleaned))) {
+            return cleaned;
+        }
+        for (String s : sourcePaths) {
+            var added = s + "/" + cleaned;
+            if (Files.exists(Path.of(added))) {
+                return added;
+            }
+        }
+        return cleaned;
+    }
+
+    private void createAnnotationsForSurvivedMutations(final AggregatedScore score,
+            final String prefix, final Set<String> sourcePaths) {
+        score.getCoveredFiles(Metric.MUTATION)
+                .forEach(file -> createAnnotationsForSurvivedMutations(file, prefix, sourcePaths));
+    }
+
+    private void createAnnotationsForSurvivedMutations(final FileNode file,
+            final String prefix, final Set<String> sourcePaths) {
+        file.getSurvivedMutationsPerLine().entrySet()
+                .forEach(entry -> createAnnotationForSurvivedMutation(file, entry, prefix, sourcePaths));
+    }
+
+    private void createAnnotationForSurvivedMutation(final FileNode file,
+            final Entry<Integer, List<Mutation>> mutationsPerLine,
+            final String prefix, final Set<String> sourcePaths) {
+        createComment(createRelativeRepositoryPath(file.getRelativePath(), prefix, sourcePaths),
+                mutationsPerLine.getKey(), mutationsPerLine.getKey(),
+                createMutationMessage(mutationsPerLine.getKey(), mutationsPerLine.getValue()), "Mutation survived",
+                NO_COLUMN, NO_COLUMN, createMutationDetails(mutationsPerLine.getValue()));
+    }
+
+    private String createMutationMessage(final int line, final List<Mutation> survived) {
+        if (survived.size() == 1) {
+            return String.format("One mutation survived in line %d (%s)", line, formatMutator(survived));
+        }
+        return String.format("%d mutations survived in line %d", survived.size(), line);
+    }
+
+    private String formatMutator(final List<Mutation> survived) {
+        return survived.get(0).getMutator().replaceAll(".*\\.", "");
+    }
+
+    private String createMutationDetails(final List<Mutation> mutations) {
+        return mutations.stream()
+                .map(mutation -> String.format("- %s (%s)", mutation.getDescription(), mutation.getMutator()))
+                .collect(Collectors.joining("\n", "Survived mutations:\n", ""));
+    }
+
+    private String getEnv(final String key, final FilteredLog log) {
+        String value = StringUtils.defaultString(System.getenv(key));
+        log.logInfo(">>>> " + key + ": " + value);
+        return value;
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/Configuration.java
+++ b/src/main/java/edu/hm/hafner/grading/Configuration.java
@@ -12,6 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import one.util.streamex.StreamEx;
 
 /**
@@ -53,13 +56,13 @@ public abstract class Configuration implements Serializable {
         return List.of(jackson.fromJson(array, type));
     }
 
-    @SuppressWarnings("NullAway") // Initialized via JSON
+    @CheckForNull @SuppressWarnings("unused") @SuppressFBWarnings("UWF_UNWRITTEN_FIELD") // Initialized via JSON
     private String id;
-    @SuppressWarnings("NullAway") // Initialized via JSON
+    @CheckForNull @SuppressWarnings("unused") @SuppressFBWarnings("UWF_UNWRITTEN_FIELD") // Initialized via JSON
     private String name;
-    @SuppressWarnings("NullAway") // Initialized via JSON
+    @CheckForNull @SuppressWarnings("unused") @SuppressFBWarnings("UWF_UNWRITTEN_FIELD") // Initialized via JSON
     private String icon;
-    @SuppressWarnings("NullAway") // Initialized via JSON
+    @SuppressWarnings("unused") @SuppressFBWarnings("UWF_UNWRITTEN_FIELD") // Initialized via JSON
     private int maxScore;
 
     private final List<ToolConfiguration> tools = new ArrayList<>();
@@ -149,7 +152,7 @@ public abstract class Configuration implements Serializable {
         if (!Objects.equals(icon, that.icon)) {
             return false;
         }
-        return tools != null ? tools.equals(that.tools) : that.tools == null;
+        return Objects.equals(tools, that.tools);
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -33,8 +33,7 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
 
     private final int coveredPercentage;
     private final Metric metric;
-    @CheckForNull
-    private final transient Node report;
+    private transient Node report; // do not persist the coverage tree
 
     private CoverageScore(final String id, final String name, final CoverageConfiguration configuration,
             final List<CoverageScore> scores) {
@@ -64,6 +63,18 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         else {
             this.coveredPercentage = 0; // If there is no coverage, then there is no code yet
         }
+    }
+
+    /**
+     * Restore an empty report after de-serialization.
+     *
+     * @return this
+     */
+    @CanIgnoreReturnValue
+    private CoverageScore readResolve() {
+        report = new ModuleNode("empty");
+
+        return this;
     }
 
     public Metric getMetric() {

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -70,8 +70,8 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
      *
      * @return this
      */
-    @CanIgnoreReturnValue
-    private CoverageScore readResolve() {
+    @Serial @CanIgnoreReturnValue
+    private Object readResolve() {
         report = new ModuleNode("empty");
 
         return this;

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  * @author Tobias Effner
  */
 public class GradingReport {
-
     private static final TestMarkdown TEST_MARKDOWN = new TestMarkdown();
     private static final AnalysisMarkdown ANALYSIS_MARKDOWN = new AnalysisMarkdown();
     private static final CodeCoverageMarkdown CODE_COVERAGE_MARKDOWN = new CodeCoverageMarkdown();
@@ -130,7 +129,6 @@ public class GradingReport {
                 score.getAchievedScore(), score.getMaxScore())
                 + createExceptionSection(exception)
                 + createLogSection(score);
-
     }
 
     private String createExceptionSection(final Throwable exception) {

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -3,6 +3,8 @@ package edu.hm.hafner.grading;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
@@ -208,7 +210,10 @@ public class AutoGradingRunnerITest extends ResourceTest {
     @Test
     @SetEnvironmentVariable(key = "CONFIG", value = CONFIGURATION)
     void shouldGradeWithConfigurationFromEnvironment() {
-        assertThat(runAutoGrading())
+        var outputStream = new ByteArrayOutputStream();
+        var runner = new AutoGradingRunner(new PrintStream(outputStream));
+        var score = runner.run();
+        assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains(new String[] {
                         "Processing 1 test configuration(s)",
@@ -227,6 +232,38 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "-> SpotBugs Total: 2 warnings",
                         "=> Bugs Score: 72 of 100",
                         "Total score - 226 of 500 (unit tests: 100/100, code coverage: 20/100, mutation coverage: 16/100, analysis: 90/200)"});
+
+        var builder = new StringCommentBuilder();
+        builder.createAnnotations(score, new FilteredLog("unused"));
+        assertThat(builder.getComments()).contains("X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:17-17: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:42-42: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:22-22: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:29-29: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:30-30: '}' sollte in derselben Zeile stehen. (CheckStyle: RightCurlyCheck)",
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:37-37: '}' sollte in derselben Zeile stehen. (CheckStyle: RightCurlyCheck)",
+                "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/env/internal/ui/actions/CopyToClipboard.java:54-61: These nested if statements could be combined. (PMD: CollapsibleIfStatements)",
+                "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/env/internal/ui/actions/change/ChangeSelectionAction.java:14-14: Avoid unused imports such as 'org.eclipse.ui.IWorkbenchPart'. (PMD: UnusedImports)",
+                "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/env/internal/ui/dialogs/SelectSourceDialog.java:938-940: Avoid empty catch blocks. (PMD: EmptyCatchBlock)",
+                "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/env/internal/ui/dialogs/SelectSourceDialog.java:980-982: Avoid empty catch blocks. (PMD: EmptyCatchBlock)",
+                "edu/hm/hafner/analysis/IssuesTest.java:286-286: Return value of Issues.get(int) ignored, but method has no side effect (SpotBugs: RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT)",
+                "edu/hm/hafner/analysis/IssuesTest.java:289-289: Return value of Issues.get(int) ignored, but method has no side effect (SpotBugs: RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT)",
+                "edu/hm/hafner/grading/ReportFactory.java:15-27: Lines 15-27 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/ReportFinder.java:62-79: Lines 62-79 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/ReportFinder.java:102-103: Lines 102-103 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/ConsoleCoverageReportFactory.java:23-49: Lines 23-49 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/FileNameRenderer.java:13-15: Lines 13-15 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/LogHandler.java:19-68: Lines 19-68 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/ConsoleTestReportFactory.java:16-27: Lines 16-27 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:41-140: Lines 41-140 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:152-153: Lines 152-153 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:160-160: Line 160 is not covered by tests (Not covered line)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:164-166: Lines 164-166 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/ConsoleAnalysisReportFactory.java:17-32: Lines 17-32 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/github/GitHubPullRequestWriter.java:40-258: Lines 40-258 are not covered by tests (Not covered lines)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:146-146: Line 146 is only partially covered, one branch is missing (Partially covered line)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:159-159: Line 159 is only partially covered, one branch is missing (Partially covered line)",
+                "edu/hm/hafner/grading/AutoGradingAction.java:147-147: One mutation survived in line 147 (VoidMethodCallMutator) (Mutation survived)",
+                "edu/hm/hafner/grading/ReportFinder.java:29-29: One mutation survived in line 29 (EmptyObjectReturnValsMutator) (Mutation survived)");
     }
 
     private String runAutoGrading() {
@@ -285,5 +322,20 @@ public class AutoGradingRunnerITest extends ResourceTest {
         assertThat(runner.getConfiguration(log)).isEqualTo("{}");
         assertThat(log.getInfoMessages()).contains("Obtaining configuration from environment variable CONFIG");
         assertThat(log.getErrorMessages()).isEmpty();
+    }
+
+    private static class StringCommentBuilder extends CommentBuilder {
+        private final List<String> comments = new ArrayList<>();
+
+        public List<String> getComments() {
+            return comments;
+        }
+
+        @Override @SuppressWarnings("checkstyle:ParameterNumber")
+        protected void createComment(final String relativePath, final int lineStart, final int lineEnd,
+                final String message, final String title,
+                final int columnStart, final int columnEnd, final String details) {
+            comments.add(String.format("%s:%d-%d: %s (%s)", relativePath, lineStart, lineEnd, message, title));
+        }
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
@@ -8,6 +8,7 @@ import edu.hm.hafner.coverage.Coverage;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.grading.CoverageScore.CoverageScoreBuilder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static edu.hm.hafner.grading.assertions.Assertions.*;
 
@@ -127,6 +128,7 @@ class CoverageScoreTest {
         return createCoverageConfiguration(missedImpact, coveredImpact, 100);
     }
 
+    @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
     private CoverageConfiguration createCoverageConfiguration(final int missedImpact, final int coveredImpact,
             final int maxScore) {
         return CoverageConfiguration.from(String.format("""


### PR DESCRIPTION
Comments for static analysis warnings, for lines with missing coverage, and for lines with survived mutations can be rendered in GitHub and GitLab using different APIs. The base class that creates the comments is now part of the model while the implementations that use the vendor specific API are placed in the corresponding actions.