### PR TITLE
Show percentages as an image

### DIFF
--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -30,7 +30,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         id: pr
       - name: Run Autograding
-        uses: uhafner/autograding-github-action@v3
+        uses: uhafner/autograding-github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -1,4 +1,4 @@
-name: 'Autograding PR'
+name: 'Reviewing quality of PR'
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ jobs:
   build:
 
     runs-on: [ubuntu-latest]
-    name: Build, test and autograde on Ubuntu
+    name: Build, test and review quality on Ubuntu
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         id: pr
       - name: Run Autograding
-        uses: uhafner/autograding-github-action@main
+        uses: uhafner/autograding-github-action@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}

--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -30,10 +30,11 @@ import edu.hm.hafner.util.FilteredLog;
  * @author Eva-Maria Zeintl
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity"})
+@SuppressWarnings({"PMD.GodClass", "PMD.CyclomaticComplexity", "PMD.ExcessivePublicCount"})
 public final class AggregatedScore implements Serializable {
     @Serial
     private static final long serialVersionUID = 3L;
+    private static final int MAX_PERCENTAGE = 100;
 
     private final FilteredLog log;
 
@@ -84,6 +85,18 @@ public final class AggregatedScore implements Serializable {
      */
     public int getAchievedScore() {
         return getTestAchievedScore() + getCoverageAchievedScore() + getAnalysisAchievedScore();
+    }
+
+    /**
+     * Returns the percentage of the achieved score.
+     *
+     * @return the percentage
+     */
+    public int getAchievedPercentage() {
+        if (getMaxScore() == 0) {
+            return MAX_PERCENTAGE;
+        }
+        return getAchievedScore() * MAX_PERCENTAGE / getMaxScore();
     }
 
     private int getAchievedScore(final List<? extends Score<?, ?>> scores) {
@@ -217,9 +230,9 @@ public final class AggregatedScore implements Serializable {
 
     private int getRatio(final int achieved, final int total) {
         if (total == 0) {
-            return 100;
+            return MAX_PERCENTAGE;
         }
-        return achieved * 100 / total;
+        return achieved * MAX_PERCENTAGE / total;
     }
 
     public int getTestRatio() {

--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -32,7 +32,9 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
         for (AnalysisScore score : scores) {
             details.addText(getTitle(score, 2))
                     .addNewline()
-                    .addText(formatColumns("Name", "Errors", "Warning High", "Warning Normal", "Warning Low", "Total"))
+                    .addText(getPercentageImage(score))
+                    .addNewline()
+                    .addText(formatColumns("Name", "Errors", "High", "Normal", "Low", "Total"))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
                     .addText(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:"))

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -126,6 +126,15 @@ public class AutoGradingRunner {
     }
 
     /**
+     * Returns the name of the default configuration file to use when the environment variable CONFIG is not set.
+     *
+     * @return the name of the default configuration file
+     */
+    protected String getDefaultConfigurationPath() {
+        return "/default-config.json";
+    }
+
+    /**
      * Creates a text in Markdown format that contains all error messages.
      *
      * @param log
@@ -162,14 +171,15 @@ public class AutoGradingRunner {
     }
 
     private String readDefaultConfiguration() {
-        try (var defaultConfig = AutoGradingRunner.class.getResourceAsStream("/default-config.json")) {
+        var name = getDefaultConfigurationPath();
+        try (var defaultConfig = AutoGradingRunner.class.getResourceAsStream(name)) {
             if (defaultConfig == null) {
-                throw new IOException("Can't find configuration in class path: default-conf.json");
+                throw new IOException("Can't find configuration in class path: " + name);
             }
             return new String(defaultConfig.readAllBytes(), StandardCharsets.UTF_8);
         }
         catch (IOException exception) {
-            throw new IllegalStateException("Can't read default configuration 'default-conf.json'", exception);
+            throw new IllegalStateException("Can't read default configuration: " + name, exception);
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -27,7 +27,7 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
         for (CoverageScore score : scores) {
             details.addText(getTitle(score, 2))
                     .addNewline()
-                    .addText(getPercentageImage(score))
+                    .addText(getImageForScoreOrCoverage(score))
                     .addNewline()
                     .addText(formatColumns("Name", coveredText, missedText))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
@@ -64,8 +64,8 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
         }
     }
 
-    private String getPercentageImage(final CoverageScore score) {
-        if (score.hasMaxScore()) {
+    private String getImageForScoreOrCoverage(final CoverageScore score) {
+        if (score.hasMaxScore()) { // show the score percentage
             return ScoreMarkdown.getPercentageImage(score.getDisplayName(), score.getPercentage());
         }
         return ScoreMarkdown.getPercentageImage(score.getDisplayName(), score.getCoveredPercentage());

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -27,6 +27,8 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
         for (CoverageScore score : scores) {
             details.addText(getTitle(score, 2))
                     .addNewline()
+                    .addText(getPercentageImage(score))
+                    .addNewline()
                     .addText(formatColumns("Name", coveredText, missedText))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
@@ -60,5 +62,12 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
                         .addNewline();
             }
         }
+    }
+
+    private String getPercentageImage(final CoverageScore score) {
+        if (score.hasMaxScore()) {
+            return ScoreMarkdown.getPercentageImage(score.getDisplayName(), score.getPercentage());
+        }
+        return ScoreMarkdown.getPercentageImage(score.getDisplayName(), score.getCoveredPercentage());
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -3,6 +3,7 @@ package edu.hm.hafner.grading;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
@@ -16,6 +17,8 @@ public class GradingReport {
     private static final CodeCoverageMarkdown CODE_COVERAGE_MARKDOWN = new CodeCoverageMarkdown();
     private static final MutationCoverageMarkdown MUTATION_COVERAGE_MARKDOWN = new MutationCoverageMarkdown();
     private static final String DEFAULT_TITLE = "Autograding score";
+    private static final String PARAGRAPH = "\n\n";
+    private static final String HORIZONTAL_RULE = "<br/>";
 
     /**
      * Returns a short summary for the grading results. This text does not use Markdown and fits into a single line.
@@ -67,8 +70,15 @@ public class GradingReport {
      */
     public String getMarkdownSummary(final AggregatedScore score, final String title) {
         var summary = getSubScoreDetails(score);
+        var percentage = createPercentage(score);
+        return createMarkdownTotal(score, title, 3) + PARAGRAPH + percentage + PARAGRAPH + summary + HORIZONTAL_RULE;
+    }
 
-        return createMarkdownTotal(score, title, 3) + "\n\n" + summary;
+    private String createPercentage(final AggregatedScore score) {
+        if (score.getMaxScore() == 0) {
+            return StringUtils.EMPTY;
+        }
+        return ScoreMarkdown.getPercentageImage("Score percentage", score.getAchievedPercentage());
     }
 
     /**
@@ -120,7 +130,7 @@ public class GradingReport {
      */
     public String getMarkdownDetails(final AggregatedScore score, final String title) {
         return createMarkdownTotal(score, title, 1)
-                + "\n\n"
+                + PARAGRAPH
                 + TEST_MARKDOWN.createDetails(score)
                 + ANALYSIS_MARKDOWN.createDetails(score)
                 + CODE_COVERAGE_MARKDOWN.createDetails(score)
@@ -135,10 +145,8 @@ public class GradingReport {
     }
 
     private String createTotal(final AggregatedScore score, final String title) {
-        if (score.getMaxScore() == 0) {
-            return String.format("%s", title);
-        }
-        return String.format("%s - %s of %s", title, score.getAchievedScore(), score.getMaxScore());
+        return title + ScoreMarkdown.createScoreTitleSuffix(score.getMaxScore(),
+                score.getAchievedScore(), score.getAchievedPercentage());
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -69,9 +69,7 @@ public class GradingReport {
      * @return Markdown text
      */
     public String getMarkdownSummary(final AggregatedScore score, final String title) {
-        var summary = getSubScoreDetails(score);
-        var percentage = createPercentage(score);
-        return createMarkdownTotal(score, title, 3) + PARAGRAPH + percentage + PARAGRAPH + summary + HORIZONTAL_RULE;
+        return createMarkdownTotal(score, title, 3) + PARAGRAPH + getSubScoreDetails(score) + HORIZONTAL_RULE;
     }
 
     private String createPercentage(final AggregatedScore score) {
@@ -91,6 +89,9 @@ public class GradingReport {
      */
     public StringBuilder getSubScoreDetails(final AggregatedScore score) {
         var summary = new StringBuilder();
+
+        summary.append(createPercentage(score)).append(PARAGRAPH);
+
         if (score.hasTests()) {
             summary.append(TEST_MARKDOWN.createSummary(score));
         }

--- a/src/main/java/edu/hm/hafner/grading/Score.java
+++ b/src/main/java/edu/hm/hafner/grading/Score.java
@@ -22,6 +22,7 @@ import edu.hm.hafner.util.Generated;
 public abstract class Score<S extends Score<S, C>, C extends Configuration> implements Serializable {
     @Serial
     private static final long serialVersionUID = 3L;
+    private static final int MAX_PERCENTAGE = 100;
 
     private final String id;
     private final String name;
@@ -101,6 +102,18 @@ public abstract class Score<S extends Score<S, C>, C extends Configuration> impl
             return 0;
         }
         return getMaxScore();
+    }
+
+    /**
+     * Returns the achieved percentage.
+     *
+     * @return the percentage
+     */
+    public int getPercentage() {
+        if (hasMaxScore()) {
+            return getValue() * MAX_PERCENTAGE / getMaxScore();
+        }
+        return MAX_PERCENTAGE;
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -35,6 +35,8 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
         for (TestScore score : scores) {
             details.addText(getTitle(score, 2))
                     .addNewline()
+                    .addText(getPercentageImage(score))
+                    .addNewline()
                     .addText(formatColumns("Name", "Passed", "Skipped", "Failed", "Total"))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()

--- a/src/main/resources/default-no-score-config.json
+++ b/src/main/resources/default-no-score-config.json
@@ -1,6 +1,5 @@
 {
   "tests": {
-    "name": "Tests",
     "tools": [
       {
         "id": "test",
@@ -8,10 +7,7 @@
         "pattern": "**/target/*-reports/TEST*.xml"
       }
     ],
-    "passedImpact": 0,
-    "skippedImpact": -1,
-    "failureImpact": -5,
-    "maxScore": 100
+    "name": "Tests"
   },
   "analysis": [
     {
@@ -28,12 +24,7 @@
           "name": "PMD",
           "pattern": "**/target/pmd.xml"
         }
-      ],
-      "errorImpact": -1,
-      "highImpact": -1,
-      "normalImpact": -1,
-      "lowImpact": -1,
-      "maxScore": 100
+      ]
     },
     {
       "name": "Bugs",
@@ -46,12 +37,7 @@
           "sourcePath": "src/main/java",
           "pattern": "**/target/spotbugsXml.xml"
         }
-      ],
-      "errorImpact": -3,
-      "highImpact": -3,
-      "normalImpact": -3,
-      "lowImpact": -3,
-      "maxScore": 100
+      ]
     }
   ],
   "coverage": [
@@ -72,9 +58,7 @@
           "sourcePath": "src/main/java",
           "pattern": "**/target/site/jacoco/jacoco.xml"
         }
-      ],
-      "maxScore": 100,
-      "missedPercentageImpact": -1
+      ]
     },
     {
       "name": "Mutation Coverage",
@@ -86,9 +70,7 @@
           "sourcePath": "src/main/java",
           "pattern": "**/target/pit-reports/mutations.xml"
         }
-      ],
-      "maxScore": 100,
-      "missedPercentageImpact": -1
+      ]
     }
   ]
 }

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -105,6 +105,8 @@ class GradingReportTest {
 
         var score = new AggregatedScoreTest().createSerializable();
         assertThat(results.getMarkdownSummary(score, "Summary")).contains(
+                "img title=\"Score percentage: 33%\"",
+                "percentages/033.svg",
                 "# :mortar_board: Summary - 167 of 500",
                 "JUnit - 77 of 100",
                 "14 tests failed, 5 passed, 3 skipped",
@@ -117,15 +119,20 @@ class GradingReportTest {
                 "Bugs - 0 of 100",
                 "10 warnings found (4 errors, 3 high, 2 normal, 1 low)");
         assertThat(results.getTextSummary(score)).isEqualTo(
-                "Autograding score - 167 of 500");
+                "Autograding score - 167 of 500 (33%)");
         assertThat(results.getMarkdownDetails(score)).contains(
-                "Autograding score - 167 of 500",
+                "Autograding score - 167 of 500 (33%)",
                 "JUnit - 77 of 100",
+                "title=\"JUnit: 77%\"",
                 "JaCoCo - 40 of 100",
+                "title=\"JaCoCo: 40%\"",
                 "PIT - 20 of 100",
+                "title=\"PIT: 20%\"",
                 "Style - 30 of 100",
+                "title=\"Style: 30%\"",
                 ":warning: Style",
                 "Bugs - 0 of 100",
+                "title=\"Bugs: 0%\"",
                 ":bug: Bugs");
     }
 
@@ -146,9 +153,9 @@ class GradingReportTest {
 
         var score = AnalysisMarkdownTest.createScoreForTwoResults();
         assertThat(results.getTextSummary(score)).isEqualTo(
-                "Autograding score - 30 of 200");
+                "Autograding score - 30 of 200 (15%)");
         assertThat(results.getMarkdownDetails(score)).contains(
-                "Autograding score - 30 of 200",
+                "Autograding score - 30 of 200 (15%)",
                 "Unit Tests Score: not enabled",
                 "Code Coverage Score: not enabled",
                 "Mutation Coverage Score: not enabled",
@@ -208,7 +215,9 @@ class GradingReportTest {
                 "# :sunny: Quality Summary",
                 "JUnit",
                 "JaCoCo",
+                "title=\"JaCoCo: 70%\"",
                 "PIT",
+                "title=\"PIT: 60%\"",
                 "Style",
                 "Bugs");
     }


### PR DESCRIPTION
New:

### :mortar_board: Summary - 167 of 500

<img title="Score percentage: 33%" width="110" height="110"
        align="left" alt="Score percentage: 33%"
        src="https://raw.githubusercontent.com/uhafner/autograding-model/main/percentages/033.svg" />


- :vertical_traffic_light: JUnit - 77 of 100: 14 tests failed, 5 passed, 3 skipped
- :footprints: JaCoCo - 40 of 100: 70% coverage achieved
- :microscope: PIT - 20 of 100: 60% mutations killed
- :warning: Style - 30 of 100: 10 warnings found (1 error, 2 high, 3 normal, 4 low)
- :bug: Bugs - 0 of 100: 10 warnings found (4 errors, 3 high, 2 normal, 1 low)
