### PR TITLE
Ignore errors while parsing test files

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/FileSystemCoverageReportFactory.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemCoverageReportFactory.java
@@ -27,7 +27,7 @@ public final class FileSystemCoverageReportFactory implements CoverageReportFact
 
     @Override
     public Node create(final ToolConfiguration tool, final FilteredLog log) {
-        var parser = new ParserRegistry().get(StringUtils.upperCase(tool.getId()), ProcessingMode.FAIL_FAST);
+        var parser = new ParserRegistry().get(StringUtils.upperCase(tool.getId()), ProcessingMode.IGNORE_ERRORS);
 
         var nodes = new ArrayList<Node>();
         for (Path file : REPORT_FINDER.find(tool, log)) {


### PR DESCRIPTION
Sometimes there might be no tests in a test class yet.