### PR TITLE
Add number of processed files to report

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -34,15 +34,16 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
                     .addNewline()
                     .addText(getPercentageImage(score))
                     .addNewline()
-                    .addText(formatColumns("Name", "Errors", "High", "Normal", "Low", "Total"))
+                    .addText(formatColumns("Name", "Files", "Errors", "High", "Normal", "Low", "Total"))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
-                    .addText(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:"))
+                    .addText(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:", ":-:"))
                     .addTextIf(formatColumns(":-:"), score.hasMaxScore())
                     .addNewline();
 
             score.getSubScores().forEach(subScore -> details
                     .addText(formatColumns(subScore.getName(),
+                            String.valueOf(subScore.getReportFiles()),
                             String.valueOf(subScore.getErrorSize()),
                             String.valueOf(subScore.getHighSeveritySize()),
                             String.valueOf(subScore.getNormalSeveritySize()),
@@ -53,6 +54,7 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
 
             if (score.getSubScores().size() > 1) {
                 details.addText(formatBoldColumns("Total",
+                                sum(score, AnalysisScore::getReportFiles),
                                 sum(score, AnalysisScore::getErrorSize),
                                 sum(score, AnalysisScore::getHighSeveritySize),
                                 sum(score, AnalysisScore::getNormalSeveritySize),
@@ -64,7 +66,7 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
 
             if (score.hasMaxScore()) {
                 var configuration = score.getConfiguration();
-                details.addText(formatColumns(IMPACT))
+                details.addText(formatColumns(IMPACT, EMPTY))
                         .addText(formatItalicColumns(
                                 renderImpact(configuration.getErrorImpact()),
                                 renderImpact(configuration.getHighImpact()),

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -92,6 +92,10 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
         return ObjectUtils.defaultIfNull(report, new Report());
     }
 
+    public int getReportFiles() {
+        return getReport().getOriginReportFiles().size();
+    }
+
     public int getErrorSize() {
         return errorSize;
     }

--- a/src/main/java/edu/hm/hafner/grading/FileSystemAnalysisReportFactory.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemAnalysisReportFactory.java
@@ -27,7 +27,7 @@ public final class FileSystemAnalysisReportFactory implements AnalysisReportFact
 
         var analysisParser = parser.createParser();
         for (Path file : REPORT_FINDER.find(tool, log)) {
-            Report report = analysisParser.parse(new FileReaderFactory(file));
+            Report report = analysisParser.parseFile(new FileReaderFactory(file));
             report.setOrigin(tool.getId(), tool.getDisplayName());
             log.logInfo("- %s: %d warnings", PATH_UTIL.getRelativePath(file), report.size());
             total.addAll(report);

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -24,6 +24,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static final String LEDGER = ":heavy_minus_sign:";
     static final String IMPACT = ":moneybag:";
     static final String TOTAL = ":heavy_minus_sign:";
+    static final String EMPTY = ":heavy_minus_sign:";
 
     static final String N_A = "-";
 

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -37,16 +37,17 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                     .addNewline()
                     .addText(getPercentageImage(score))
                     .addNewline()
-                    .addText(formatColumns("Name", "Passed", "Skipped", "Failed", "Total"))
+                    .addText(formatColumns("Name", "Files", "Passed", "Skipped", "Failed", "Total"))
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
-                    .addText(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:"))
+                    .addText(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:"))
                     .addTextIf(formatColumns(":-:"), score.hasMaxScore())
                     .addNewline();
 
             score.getSubScores().forEach(subScore -> details
                     .addText(formatColumns(
                             subScore.getName(),
+                            String.valueOf(subScore.getReportFiles()),
                             String.valueOf(subScore.getPassedSize()),
                             String.valueOf(subScore.getSkippedSize()),
                             String.valueOf(subScore.getFailedSize()),
@@ -56,6 +57,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
 
             if (score.getSubScores().size() > 1) {
                 details.addText(formatBoldColumns("Total",
+                                sum(score, TestScore::getReportFiles),
                                 sum(score, TestScore::getPassedSize),
                                 sum(score, TestScore::getSkippedSize),
                                 sum(score, TestScore::getFailedSize),
@@ -66,7 +68,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
 
             var configuration = score.getConfiguration();
             if (score.hasMaxScore()) {
-                details.addText(formatColumns(IMPACT))
+                details.addText(formatColumns(IMPACT, EMPTY))
                         .addText(formatItalicColumns(
                                 renderImpact(configuration.getPassedImpact()),
                                 renderImpact(configuration.getSkippedImpact()),

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import edu.hm.hafner.coverage.ContainerNode;
+import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.TestCase;
@@ -86,6 +87,10 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
     @JsonIgnore
     public Node getReport() {
         return report;
+    }
+
+    public int getReportFiles() {
+        return report.getAll(Metric.MODULE).size();
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 class AnalysisMarkdownTest {
-    private static final String IMPACT_CONFIGURATION = ":moneybag:|*-1*|*-2*|*-3*|*-4*|:heavy_minus_sign:|:heavy_minus_sign:";
+    private static final String IMPACT_CONFIGURATION = ":moneybag:|:heavy_minus_sign:|*-1*|*-2*|*-3*|*-4*|:heavy_minus_sign:|:heavy_minus_sign:";
     private static final FilteredLog LOG = new FilteredLog("Test");
 
     @Test
@@ -89,7 +89,7 @@ class AnalysisMarkdownTest {
                 "- :warning: CheckStyle - 70 of 100: 10 warnings found (1 error, 2 high, 3 normal, 4 low)");
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("CheckStyle - 70 of 100")
-                .contains("|CheckStyle 1|1|2|3|4|10|-30")
+                .contains("|CheckStyle 1|1|1|2|3|4|10|-30")
                 .contains(IMPACT_CONFIGURATION);
     }
 
@@ -127,10 +127,10 @@ class AnalysisMarkdownTest {
                 .startsWith("- :warning: CheckStyle - 50 of 100: 20 warnings found (5 errors, 5 high, 5 normal, 5 low)");
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("CheckStyle - 50 of 100",
-                        "|CheckStyle|1|2|3|4|10|-30",
-                        "|SpotBugs|4|3|2|1|10|-20",
+                        "|CheckStyle|1|1|2|3|4|10|-30",
+                        "|SpotBugs|1|4|3|2|1|10|-20",
                         IMPACT_CONFIGURATION,
-                        "**Total**|**5**|**5**|**5**|**5**|**20**|**-50**");
+                        "**Total**|**2**|**5**|**5**|**5**|**5**|**20**|**-50**");
     }
 
     @Test
@@ -162,9 +162,9 @@ class AnalysisMarkdownTest {
                 .startsWith("- :warning: CheckStyle: 20 warnings found (5 errors, 5 high, 5 normal, 5 low)");
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("CheckStyle",
-                        "|CheckStyle|1|2|3|4|10",
-                        "|SpotBugs|4|3|2|1|10",
-                        "**Total**|**5**|**5**|**5**|**5**|**20**")
+                        "|CheckStyle|1|1|2|3|4|10",
+                        "|SpotBugs|1|4|3|2|1|10",
+                        "**Total**|**2**|**5**|**5**|**5**|**5**|**20**")
                 .doesNotContain(IMPACT_CONFIGURATION)
                 .doesNotContain("Impact");
     }
@@ -203,15 +203,15 @@ class AnalysisMarkdownTest {
 
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("Style - 60 of 100",
-                        "|CheckStyle 1|1|2|3|4|10|30",
-                        "|CheckStyle 2|1|2|3|4|10|30",
-                        "|**Total**|**2**|**4**|**6**|**8**|**20**|**60**",
+                        "|CheckStyle 1|1|1|2|3|4|10|30",
+                        "|CheckStyle 2|1|1|2|3|4|10|30",
+                        "|**Total**|**2**|**2**|**4**|**6**|**8**|**20**|**60**",
                         "Bugs - 0 of 100",
-                        "|SpotBugs 1|4|3|2|1|10|-120",
-                        "|SpotBugs 2|4|3|2|1|10|-120",
-                        "|**Total**|**8**|**6**|**4**|**2**|**20**|**-240**",
-                        ":moneybag:|*1*|*2*|*3*|*4*|:heavy_minus_sign:|:heavy_minus_sign:",
-                        ":moneybag:|*-11*|*-12*|*-13*|*-14*|:heavy_minus_sign:|:heavy_minus_sign:");
+                        "|SpotBugs 1|1|4|3|2|1|10|-120",
+                        "|SpotBugs 2|1|4|3|2|1|10|-120",
+                        "|**Total**|**2**|**8**|**6**|**4**|**2**|**20**|**-240**",
+                        ":moneybag:|:heavy_minus_sign:|*1*|*2*|*3*|*4*|:heavy_minus_sign:|:heavy_minus_sign:",
+                        ":moneybag:|:heavy_minus_sign:|*-11*|*-12*|*-13*|*-14*|:heavy_minus_sign:|:heavy_minus_sign:");
         assertThat(analysisMarkdown.createSummary(score))
                 .contains("- :warning: Style - 60 of 100: 20 warnings found (2 errors, 4 high, 6 normal, 8 low)",
                         "- :warning: Bugs - 0 of 100: 20 warnings found (8 errors, 6 high, 4 normal, 2 low)")

--- a/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
@@ -297,7 +297,7 @@ class AnalysisScoreTest {
 
     static Report createReportWith(final String name, final Severity... severities) {
         var report = new Report("checkstyle", name);
-
+        report.setOriginReportFile(name + ".xml");
         try (var builder = new IssueBuilder()) {
             for (int i = 0; i < severities.length; i++) {
                 Severity severity = severities[i];

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -159,11 +159,11 @@ class GradingReportTest {
                 "Unit Tests Score: not enabled",
                 "Code Coverage Score: not enabled",
                 "Mutation Coverage Score: not enabled",
-                "|CheckStyle 1|1|2|3|4|10|30",
-                "|CheckStyle 2|1|2|3|4|10|30",
+                "|CheckStyle 1|1|1|2|3|4|10|30",
+                "|CheckStyle 2|1|1|2|3|4|10|30",
                 "Style - 60 of 100",
-                "|SpotBugs 1|4|3|2|1|10|-120",
-                "|SpotBugs 2|4|3|2|1|10|-120",
+                "|SpotBugs 1|1|4|3|2|1|10|-120",
+                "|SpotBugs 2|1|4|3|2|1|10|-120",
                 "Bugs - 0 of 100");
     }
 

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 class TestMarkdownTest {
-    private static final String IMPACT_CONFIGURATION = ":moneybag:|*10*|*-1*|*-5*|:heavy_minus_sign:|:heavy_minus_sign:";
+    private static final String IMPACT_CONFIGURATION = ":moneybag:|:heavy_minus_sign:|*10*|*-1*|*-5*|:heavy_minus_sign:|:heavy_minus_sign:";
     private static final FilteredLog LOG = new FilteredLog("Test");
     private static final int TOO_MANY_FAILURES = 400;
 
@@ -54,8 +54,8 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("Tests - 100 of 100")
-                .contains("|JUnit|0|0|0|0|0")
-                .contains(":moneybag:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:");
+                .contains("|JUnit|1|0|0|0|0|0")
+                .contains(":moneybag:|:heavy_minus_sign:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:");
         assertThat(testMarkdown.createSummary(score))
                 .contains("Tests - 100 of 100")
                 .contains("0 tests passed");
@@ -88,7 +88,7 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 27 of 100")
-                .contains("|JUnit|5|3|4|12|27")
+                .contains("|JUnit|1|5|3|4|12|27")
                 .contains(IMPACT_CONFIGURATION);
         assertThat(testMarkdown.createSummary(score))
                 .contains("JUnit - 27 of 100", "4 tests failed, 5 passed, 3 skipped");
@@ -125,10 +125,10 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 77 of 100",
-                        "|Integrationstests|5|3|4|12|27",
-                        "|Modultests|0|0|10|10|-50",
+                        "|Integrationstests|1|5|3|4|12|27",
+                        "|Modultests|1|0|0|10|10|-50",
                         IMPACT_CONFIGURATION,
-                        "**Total**|**5**|**3**|**14**|**22**|**-23**",
+                        "**Total**|**2**|**5**|**3**|**14**|**22**|**-23**",
                         "### Skipped Test Cases",
                         "- test-class-skipped-0#test-skipped-0",
                         "- test-class-skipped-1#test-skipped-1",
@@ -165,9 +165,9 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit",
-                        "|Integrationstests|5|3|4|12",
-                        "|Modultests|0|0|10|10",
-                        "**Total**|**5**|**3**|**14**|**22**",
+                        "|Integrationstests|1|5|3|4|12",
+                        "|Modultests|1|0|0|10|10",
+                        "**Total**|**2**|**5**|**3**|**14**|**22**",
                         "### Skipped Test Cases",
                         "- test-class-skipped-0#test-skipped-0",
                         "- test-class-skipped-1#test-skipped-1",
@@ -248,15 +248,15 @@ class TestMarkdownTest {
         assertThat(testMarkdown.createDetails(score))
                 .containsIgnoringWhitespaces(
                         "One - 46 of 100",
-                        "|Integrationstests 1|5|3|4|12|23",
-                        "|Integrationstests 2|5|3|4|12|23",
-                        "|**Total**|**10**|**6**|**8**|**24**|**46**",
+                        "|Integrationstests 1|1|5|3|4|12|23",
+                        "|Integrationstests 2|1|5|3|4|12|23",
+                        "|**Total**|**2**|**10**|**6**|**8**|**24**|**46**",
                         "Two - 40 of 100",
-                        "|Modultests 1|0|0|10|10|-30",
-                        "|Modultests 2|0|0|10|10|-30",
-                        "|**Total**|**0**|**0**|**20**|**20**|**-60**",
-                        ":moneybag:|*1*|*2*|*3*|:heavy_minus_sign:|:heavy_minus_sign:",
-                        ":moneybag:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:",
+                        "|Modultests 1|1|0|0|10|10|-30",
+                        "|Modultests 2|1|0|0|10|10|-30",
+                        "|**Total**|**2**|**0**|**0**|**20**|**20**|**-60**",
+                        ":moneybag:|:heavy_minus_sign:|*1*|*2*|*3*|:heavy_minus_sign:|:heavy_minus_sign:",
+                        ":moneybag:|:heavy_minus_sign:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:",
                         "__test-class-failed-0:test-failed-0__",
                         "__test-class-failed-1:test-failed-1__",
                         "__test-class-failed-2:test-failed-2__",


### PR DESCRIPTION
With https://github.com/uhafner/codingstyle-pom/releases/tag/v4.0.0 a project has multiple reports for CheckStyle and PMD by default. It makes sense to show the number of processed reports as well.