### PR TITLE
Add a flag to hide the descriptions

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
--Pconsume-incrementals
 -Pmight-produce-incrementals
 

--- a/src/main/java/edu/hm/hafner/grading/AnalysisConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisConfiguration.java
@@ -22,7 +22,7 @@ public final class AnalysisConfiguration extends Configuration {
      * Converts the specified JSON object to a list of {@link AnalysisConfiguration} instances.
      *
      * @param json
-     *         the json object to convert
+     *         the JSON object to convert
      *
      * @return the corresponding {@link AnalysisConfiguration} instances
      */

--- a/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/CommentBuilder.java
@@ -26,9 +26,6 @@ import edu.hm.hafner.util.PathUtil;
  * @author Ullrich Hafner
  */
 public abstract class CommentBuilder {
-    private int warningComments;
-    private int coverageComments;
-
     /**
      * Describes the type of the comment. Is the comment for a warning, a missed line, a partially covered line, or a
      * survived mutation?
@@ -43,6 +40,9 @@ public abstract class CommentBuilder {
     private static final int NO_COLUMN = -1;
     private static final String NO_ADDITIONAL_DETAILS = StringUtils.EMPTY;
     private static final PathUtil PATH_UTIL = new PathUtil();
+
+    private int warningComments;
+    private int coverageComments;
 
     private final List<String> prefixes;
 
@@ -157,17 +157,36 @@ public abstract class CommentBuilder {
         }
     }
 
+    /**
+     * Returns the maximum number of warning comments to create.
+     *
+     * @return the maximum number of warning comments
+     */
     protected int getMaxWarningComments() {
         return Integer.MAX_VALUE;
     }
 
+    /**
+     * Returns whether the description of the warning will be hidden. By default, the description will be shown.
+     *
+     * @return {@code true} if the description will be hidden, {@code false} if the description will be shown
+     */
+    protected boolean isWarningDescriptionHidden() {
+        return false;
+    }
+
+    /**
+     * Returns the maximum number of coverage comments to create.
+     *
+     * @return the maximum number of coverage comments
+     */
     protected int getMaxCoverageComments() {
         return Integer.MAX_VALUE;
     }
 
     private String getDescription(final Issue issue) {
         var parserRegistry = new ParserRegistry();
-        if (parserRegistry.contains(issue.getOrigin())) {
+        if (!isWarningDescriptionHidden() && parserRegistry.contains(issue.getOrigin())) {
             return parserRegistry.get(issue.getOrigin()).getDescription(issue);
         }
         return issue.getDescription();

--- a/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
@@ -300,6 +300,7 @@ class AnalysisScoreTest {
                 var text = severity.toString() + "-" + i;
                 report.add(builder.setMessage(text)
                         .setFileName(text)
+                        .setType("DesignForExtensionCheck")
                         .setSeverity(severity).build());
             }
         }


### PR DESCRIPTION
When students create a lot of issues, it makes sense to hide the descriptions.