### PR TITLE
Fix handling of newlines and paragraphs

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -34,7 +34,7 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
             final TruncatedStringBuilder details) {
         for (AnalysisScore score : scores) {
             details.addText(getTitle(score, 2))
-                    .addNewline()
+                    .addParagraph()
                     .addText(getPercentageImage(score))
                     .addNewline()
                     .addText(formatColumns("Name", "Reports", "Errors", "High", "Normal", "Low", "Total"))
@@ -78,6 +78,8 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
                         .addText(formatColumns(TOTAL, LEDGER))
                         .addNewline();
             }
+
+            details.addNewline();
         }
     }
 

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -215,7 +215,7 @@ public class AutoGradingRunner {
         if (log.hasErrors()) {
             var errors = new StringBuilder(ERROR_CAPACITY);
 
-            errors.append("\n## :construction: Error Messages\n```\n");
+            errors.append("\n### :construction: Error Messages\n\n```\n");
             var messages = new StringJoiner("\n");
             log.getErrorMessages().forEach(messages::add);
             errors.append(messages);

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -26,7 +26,7 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
             final TruncatedStringBuilder details) {
         for (CoverageScore score : scores) {
             details.addText(getTitle(score, 2))
-                    .addNewline()
+                    .addParagraph()
                     .addText(getImageForScoreOrCoverage(score))
                     .addNewline()
                     .addText(formatColumns("Name", coveredText, missedText))
@@ -61,6 +61,8 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
                         .addText(formatColumns(LEDGER))
                         .addNewline();
             }
+
+            details.addNewline();
         }
     }
 

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -92,18 +93,21 @@ public class GradingReport {
 
         summary.append(createPercentage(score));
 
+        var summaries = new ArrayList<String>();
         if (score.hasTests()) {
-            summary.append(TEST_MARKDOWN.createSummary(score));
+            summaries.add(TEST_MARKDOWN.createSummary(score));
         }
         if (score.hasCodeCoverage()) {
-            summary.append(CODE_COVERAGE_MARKDOWN.createSummary(score));
+            summaries.add(CODE_COVERAGE_MARKDOWN.createSummary(score));
         }
         if (score.hasMutationCoverage()) {
-            summary.append(MUTATION_COVERAGE_MARKDOWN.createSummary(score));
+            summaries.add(MUTATION_COVERAGE_MARKDOWN.createSummary(score));
         }
         if (score.hasAnalysis()) {
-            summary.append(ANALYSIS_MARKDOWN.createSummary(score));
+            summaries.add(ANALYSIS_MARKDOWN.createSummary(score));
         }
+        summary.append(String.join(ScoreMarkdown.LINE_BREAK_PARAGRAPH, summaries));
+        summary.append(ScoreMarkdown.PARAGRAPH);
         return summary;
     }
 

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -39,7 +39,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static final int CAPACITY = 1024;
 
     private static final int MAX_SIZE = 10_000; // limit the size of the output to this number of characters
-    private static final String TRUNCATION_TEXT = "\n\nToo many test failures. Grading output truncated.";
+    private static final String TRUNCATION_TEXT = "\n\nToo many test failures. Grading output truncated.\n\n";
     private static final int HUNDRED_PERCENT = 100;
 
     private final String type;

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -26,7 +27,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     protected static final int ICON_SIZE = 18;
     static final String SPACE = "&nbsp;";
-    static final String LINE_BREAK = "\\\n";
+    static final String LINE_BREAK_PARAGRAPH = "\\\n";
+    static final String LINE_BREAK = "\n";
+    static final String PARAGRAPH = "\n\n";
     static final String LEDGER = ":heavy_minus_sign:";
     static final String IMPACT = ":moneybag:";
     static final String TOTAL = ":heavy_minus_sign:";
@@ -122,11 +125,11 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
             return createNotEnabled();
         }
 
-        var summary = new StringBuilder(CAPACITY);
+        var summaries = new ArrayList<String>();
         for (S score : scores) {
-            summary.append(createSummary(score));
+            summaries.add(createSummary(score));
         }
-        return summary.toString();
+        return String.join(LINE_BREAK_PARAGRAPH, summaries);
     }
 
     protected abstract String createSummary(S score);

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -1,10 +1,8 @@
 package edu.hm.hafner.grading;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -80,29 +78,24 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                         .addNewline();
             }
 
-            var info = new ArrayList<String>();
             if (score.hasSkippedTests()) {
-                var skipped = "### Skipped Test Cases"
-                        + ScoreMarkdown.PARAGRAPH
-                        + score.getSkippedTests().stream()
+                details.addNewline()
+                        .addText("### Skipped Test Cases").addNewline();
+                score.getSkippedTests().stream()
                         .map(this::renderSkippedTest)
-                        .collect(Collectors.joining(ScoreMarkdown.LINE_BREAK));
-                info.add(skipped);
+                        .map(s -> ScoreMarkdown.LINE_BREAK + s)
+                        .forEach(details::addText);
             }
 
             if (score.hasFailures()) {
-                var failures = "### Failures"
-                        + ScoreMarkdown.PARAGRAPH
-                        + score.getFailures().stream()
+                details.addNewline().addText("### Failures").addNewline();
+                score.getFailures().stream()
                         .map(this::renderFailure)
-                        .collect(Collectors.joining(ScoreMarkdown.LINE_BREAK));
-                info.add(failures);
+                        .map(s -> ScoreMarkdown.LINE_BREAK + s)
+                        .forEach(details::addText);
             }
 
             details.addNewline();
-            if (!info.isEmpty()) {
-                details.addText(String.join(ScoreMarkdown.PARAGRAPH, info)).addNewline();
-            }
         }
     }
 

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -79,24 +79,24 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
             }
 
             if (score.hasSkippedTests()) {
-                details.addNewline()
-                        .addText("### Skipped Test Cases").addNewline();
-                score.getSkippedTests().stream()
-                        .map(this::renderSkippedTest)
-                        .map(s -> ScoreMarkdown.LINE_BREAK + s)
-                        .forEach(details::addText);
+                addTestDetails(details, "### Skipped Test Cases", score.getSkippedTests(), this::renderSkippedTest);
             }
 
             if (score.hasFailures()) {
-                details.addNewline().addText("### Failures").addNewline();
-                score.getFailures().stream()
-                        .map(this::renderFailure)
-                        .map(s -> ScoreMarkdown.LINE_BREAK + s)
-                        .forEach(details::addText);
+                addTestDetails(details, "### Failures", score.getFailures(), this::renderFailure);
             }
 
             details.addNewline();
         }
+    }
+
+    private void addTestDetails(final TruncatedStringBuilder details,
+            final String title, final List<TestCase> testCases, final Function<TestCase, String> renderer) {
+        details.addNewline().addText(title).addNewline();
+        testCases.stream()
+                .map(renderer)
+                .map(s -> LINE_BREAK + s)
+                .forEach(details::addText);
     }
 
     private String renderSkippedTest(final TestCase issue) {

--- a/src/main/java/edu/hm/hafner/grading/TruncatedString.java
+++ b/src/main/java/edu/hm/hafner/grading/TruncatedString.java
@@ -135,7 +135,7 @@ public final class TruncatedString {
          */
         @CanIgnoreReturnValue
         public TruncatedStringBuilder addText(final String text) {
-            this.chunks.add(text);
+            chunks.add(text);
             return this;
         }
 
@@ -152,7 +152,7 @@ public final class TruncatedString {
         @CanIgnoreReturnValue
         public TruncatedStringBuilder addTextIf(final String text, final boolean guard) {
             if (guard) {
-                this.chunks.add(text);
+                chunks.add(text);
             }
             return this;
         }
@@ -164,7 +164,19 @@ public final class TruncatedString {
          */
         @CanIgnoreReturnValue
         public TruncatedStringBuilder addNewline() {
-            this.chunks.add("\n");
+            chunks.add("\n");
+            return this;
+        }
+
+        /**
+         * Adds a paragraph to the builder. A paragraph consists of two newlines.
+         *
+         * @return this builder
+         */
+        @CanIgnoreReturnValue
+        public TruncatedStringBuilder addParagraph() {
+            addNewline();
+            addNewline();
             return this;
         }
 
@@ -203,6 +215,11 @@ public final class TruncatedString {
         public TruncatedStringBuilder setChunkOnNewlines() {
             this.chunkOnNewlines = true;
             return this;
+        }
+
+        @Override
+        public String toString() {
+            return build().toString();
         }
     }
 
@@ -278,6 +295,7 @@ public final class TruncatedString {
                         chunks.remove(chunks.size() - 1);
                     }
                     chunks.add(truncationText);
+                    chunks.add("\n\n");
                 }
                 return chunks;
             }

--- a/src/main/java/edu/hm/hafner/grading/TruncatedString.java
+++ b/src/main/java/edu/hm/hafner/grading/TruncatedString.java
@@ -175,8 +175,7 @@ public final class TruncatedString {
          */
         @CanIgnoreReturnValue
         public TruncatedStringBuilder addParagraph() {
-            addNewline();
-            addNewline();
+            chunks.add("\n\n");
             return this;
         }
 
@@ -295,7 +294,6 @@ public final class TruncatedString {
                         chunks.remove(chunks.size() - 1);
                     }
                     chunks.add(truncationText);
-                    chunks.add("\n\n");
                 }
                 return chunks;
             }

--- a/src/test/java/edu/hm/hafner/grading/TruncatedStringTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TruncatedStringTest.java
@@ -16,6 +16,34 @@ class TruncatedStringTest {
 
     @ParameterizedTest(name = "chunkOnNewlines={0}, chunkOnChars={1}")
     @MethodSource("parameters")
+    public void shouldAddNewlines(final boolean chunkOnNewlines, final boolean chunkOnChars) {
+        var builder = createBuilder(chunkOnNewlines);
+
+        builder.addText("Hello").addNewline();
+        assertThat(getRawString(builder)).isEqualTo("Hello\n");
+        assertThat(build(builder, chunkOnChars, 1000)).isEqualTo("Hello\n");
+
+        builder.addText(", world!");
+        assertThat(getRawString(builder)).isEqualTo("Hello\n, world!");
+        assertThat(build(builder, chunkOnChars, 1000)).isEqualTo("Hello\n, world!");
+    }
+
+    @ParameterizedTest(name = "chunkOnNewlines={0}, chunkOnChars={1}")
+    @MethodSource("parameters")
+    public void shouldAddParagraphs(final boolean chunkOnNewlines, final boolean chunkOnChars) {
+        var builder = createBuilder(chunkOnNewlines);
+
+        builder.addText("Hello").addParagraph();
+        assertThat(getRawString(builder)).isEqualTo("Hello\n\n");
+        assertThat(build(builder, chunkOnChars, 1000)).isEqualTo("Hello\n\n");
+
+        builder.addText(", world!");
+        assertThat(getRawString(builder)).isEqualTo("Hello\n\n, world!");
+        assertThat(build(builder, chunkOnChars, 1000)).isEqualTo("Hello\n\n, world!");
+    }
+
+    @ParameterizedTest(name = "chunkOnNewlines={0}, chunkOnChars={1}")
+    @MethodSource("parameters")
     public void shouldBuildStrings(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         var builder = createBuilder(chunkOnNewlines);
 


### PR DESCRIPTION
GitHub and GitLab handle newlines in Markdown differently. All elements are now correctly provided as standalone blocks that can be concatenated on demand.

Will fix #381.