### PR TITLE
Improve rendering of details and summary

### DIFF
--- a/.github/workflows/quality-monitor.yml
+++ b/.github/workflows/quality-monitor.yml
@@ -42,3 +42,92 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}
+          config: >
+            {
+              "tests": {
+                "tools": [
+                  {
+                    "id": "test",
+                    "name": "Tests",
+                    "pattern": "**/target/*-reports/TEST*.xml"
+                  }
+                ],
+                "name": "Tests"
+              },
+              "analysis": [
+                {
+                  "name": "Style",
+                  "id": "style",
+                  "tools": [
+                    {
+                      "id": "checkstyle",
+                      "pattern": "**/target/**checkstyle-result.xml"
+                    },
+                    {
+                      "id": "pmd",
+                      "pattern": "**/target/**pmd.xml"
+                    }
+                  ]
+                },
+                {
+                  "name": "Bugs",
+                  "id": "bugs",
+                  "icon": "bug",
+                  "tools": [
+                    {
+                      "id": "spotbugs",
+                      "sourcePath": "src/main/java",
+                      "pattern": "**/target/spotbugsXml.xml"
+                    },
+                    {
+                      "id": "error-prone",
+                      "pattern": "**/maven.log"
+                    }
+                  ]
+                },
+                {
+                  "name": "Vulnerabilities",
+                  "id": "vulnerabilities",
+                  "icon": "shield",
+                  "tools": [
+                    {
+                      "id": "owasp-dependency-check",
+                      "pattern": "**/target/dependency-check-report.json"                    
+                    }
+                  ]
+                }
+              ],
+              "coverage": [
+                {
+                  "name": "Code Coverage",
+                  "tools": [
+                    {
+                      "id": "jacoco",
+                      "name": "Line Coverage",
+                      "metric": "line",
+                      "sourcePath": "src/main/java",
+                      "pattern": "**/target/site/jacoco/jacoco.xml"
+                    },
+                    {
+                      "id": "jacoco",
+                      "name": "Branch Coverage",
+                      "metric": "branch",
+                      "sourcePath": "src/main/java",
+                      "pattern": "**/target/site/jacoco/jacoco.xml"
+                    }
+                  ]
+                },
+                {
+                  "name": "Mutation Coverage",
+                  "tools": [
+                    {
+                      "id": "pit",
+                      "name": "Mutation Coverage",
+                      "metric": "mutation",
+                      "sourcePath": "src/main/java",
+                      "pattern": "**/target/pit-reports/mutations.xml"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -88,17 +88,9 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
     }
 
     @Override
-    protected String createSummary(final AnalysisScore score) {
-        var builder = new StringBuilder();
-        for (AnalysisScore analysisScore : score.getSubScores()) {
-            builder.append(SPACE)
-                    .append(SPACE)
-                    .append(getIconAndName(analysisScore))
-                    .append(": ")
-                    .append(analysisScore.createSummary())
-                    .append(LINE_BREAK);
-        }
-        return builder.toString();
+    protected List<String> createSummary(final AnalysisScore score) {
+        return score.getSubScores().stream()
+                .map(s -> SPACE + SPACE + getIconAndName(s) + ": " + s.createSummary()).toList();
     }
 
     private String getIconAndName(final AnalysisScore analysisScore) {

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -74,17 +74,8 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
     }
 
     @Override
-    protected String createSummary(final CoverageScore score) {
-        var summary = new StringBuilder(CAPACITY);
-
-        for (CoverageScore coverageScore : score.getSubScores()) {
-            summary.append(SPACE)
-                    .append(SPACE)
-                    .append(getTitle(coverageScore, 0))
-                    .append(": ")
-                    .append(coverageScore.createSummary())
-                    .append(LINE_BREAK);
-        }
-        return summary.toString();
+    protected List<String> createSummary(final CoverageScore score) {
+        return score.getSubScores().stream()
+                .map(s -> SPACE + SPACE + getTitle(s, 0) + ": " + s.createSummary()).toList();
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -134,12 +134,27 @@ public class GradingReport {
      * @return Markdown text
      */
     public String getMarkdownDetails(final AggregatedScore score, final String title) {
+        return getMarkdownDetails(score, title, false);
+    }
+
+    /**
+     * Creates a detailed description of the grading results in Markdown.
+     *
+     * @param score
+     *         the aggregated score
+     * @param title
+     *         the title of the details
+     * @param showDisabled
+     *        determines whether disabled scores should be shown or skipped
+     * @return Markdown text
+     */
+    public String getMarkdownDetails(final AggregatedScore score, final String title, final boolean showDisabled) {
         return createMarkdownTotal(score, title, 1)
                 + PARAGRAPH
-                + TEST_MARKDOWN.createDetails(score)
-                + ANALYSIS_MARKDOWN.createDetails(score)
-                + CODE_COVERAGE_MARKDOWN.createDetails(score)
-                + MUTATION_COVERAGE_MARKDOWN.createDetails(score);
+                + TEST_MARKDOWN.createDetails(score, showDisabled)
+                + ANALYSIS_MARKDOWN.createDetails(score, showDisabled)
+                + CODE_COVERAGE_MARKDOWN.createDetails(score, showDisabled)
+                + MUTATION_COVERAGE_MARKDOWN.createDetails(score, showDisabled);
     }
 
     private String createMarkdownTotal(final AggregatedScore score, final String title, final int size) {

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -29,6 +29,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static final String SPACE = "&nbsp;";
     static final String LINE_BREAK_PARAGRAPH = "\\\n";
     static final String LINE_BREAK = "\n";
+    static final String HORIZONTAL_RULE = "<hr />\n\n";
     static final String PARAGRAPH = "\n\n";
     static final String LEDGER = ":heavy_minus_sign:";
     static final String IMPACT = ":moneybag:";

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -35,6 +35,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static final String IMPACT = ":moneybag:";
     static final String TOTAL = ":heavy_minus_sign:";
     static final String EMPTY = ":heavy_minus_sign:";
+    static final int DEFAULT_PERCENTAGE_SIZE = 110;
 
     static final String N_A = "-";
     static final int CAPACITY = 1024;
@@ -64,14 +65,32 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
             justification = "Output is Unix anyway")
     public static String getPercentageImage(final String title, final int percentage) {
+        return getPercentageImage(title, percentage, DEFAULT_PERCENTAGE_SIZE);
+    }
+
+    /**
+     * Creates a percentage image tag.
+     *
+     * @param title
+     *         the title of the image
+     * @param percentage
+     *         the percentage to show
+     * @param size
+     *         the size of the image
+     *
+     * @return Markdown text
+     */
+    @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
+            justification = "Output is Unix anyway")
+    public static String getPercentageImage(final String title, final int percentage, final int size) {
         if (percentage < 0 || percentage > HUNDRED_PERCENT) {
             throw new IllegalArgumentException("Percentage must be between 0 and 100: " + percentage);
         }
         return format("""
-                <img title="%s: %d%%" width="110" height="110"
+                <img title="%s: %d%%" width="%d" height="%d"
                         align="left" alt="%s: %d%%"
                         src="https://raw.githubusercontent.com/uhafner/autograding-model/main/percentages/%03d.svg" />
-                """, title, percentage, title, percentage, percentage);
+                """, title, percentage, size, size, title, percentage, percentage);
     }
 
     String getPercentageImage(final Score<?, ?> score) {
@@ -134,20 +153,15 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
      *
      * @return returns the summary in Markdown
      */
-    public String createSummary(final AggregatedScore aggregation) {
-        var scores = createScores(aggregation);
-        if (scores.isEmpty()) {
-            return createNotEnabled(false);
-        }
-
+    public List<String> createSummary(final AggregatedScore aggregation) {
         var summaries = new ArrayList<String>();
-        for (S score : scores) {
-            summaries.add(createSummary(score));
+        for (S score : createScores(aggregation)) {
+            summaries.addAll(createSummary(score));
         }
-        return String.join(LINE_BREAK_PARAGRAPH, summaries);
+        return summaries;
     }
 
-    protected abstract String createSummary(S score);
+    protected abstract List<String> createSummary(S score);
 
     /**
      * Creates the scores to render.

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -89,9 +89,23 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
      * @return formatted Markdown
      */
     public String createDetails(final AggregatedScore aggregation) {
+        return createDetails(aggregation, false);
+    }
+
+    /**
+     * Renders the score details in Markdown.
+     *
+     * @param aggregation
+     *         aggregated score
+     * @param showDisabled
+     *         determines whether disabled scores should be shown or skipped
+     *
+     * @return formatted Markdown
+     */
+    public String createDetails(final AggregatedScore aggregation, final boolean showDisabled) {
         var scores = createScores(aggregation);
         if (scores.isEmpty()) {
-            return createNotEnabled();
+            return createNotEnabled(showDisabled);
         }
 
         var details = new TruncatedStringBuilder().withTruncationText(TRUNCATION_TEXT);
@@ -122,7 +136,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     public String createSummary(final AggregatedScore aggregation) {
         var scores = createScores(aggregation);
         if (scores.isEmpty()) {
-            return createNotEnabled();
+            return createNotEnabled(false);
         }
 
         var summaries = new ArrayList<String>();
@@ -236,7 +250,10 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
         }
     }
 
-    protected String createNotEnabled() {
-        return String.format("## :%s: %s%s %n", icon, type, ": not enabled");
+    protected String createNotEnabled(final boolean showDisabled) {
+        if (showDisabled) {
+            return String.format("## :%s: %s%s %n%n", icon, type, ": not enabled");
+        }
+        return StringUtils.EMPTY;
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -144,7 +144,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
     }
 
     @Override
-    protected String createSummary(final TestScore score) {
+    protected List<String> createSummary(final TestScore score) {
         var summary = new StringBuilder(CAPACITY);
 
         summary.append(SPACE)
@@ -166,6 +166,6 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
             }
             summary.append(joiner);
         }
-        return summary.toString();
+        return List.of(summary.toString());
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -120,7 +120,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                   %s
                   ```
 
-                """, issue.getMessage());
+                """, issue.getMessage().trim());
     }
 
     private String getStacktrace(final TestCase issue) {
@@ -136,7 +136,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                   ```
                 </details>
                 
-                """, issue.getDescription());
+                """, issue.getDescription().trim());
     }
 
     private int sum(final TestScore score, final Function<TestScore, Integer> property) {

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -104,26 +104,39 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
     }
 
     private String renderFailure(final TestCase issue) {
-        return format("__%s:%s__", issue.getClassName(), issue.getTestName())
-                + getMessage(issue)
+        return HORIZONTAL_RULE
+                + format("__%s:%s__", issue.getClassName(), issue.getTestName())
                 + PARAGRAPH
-                + format("""
-                <details>
-                  <summary>Stack Trace</summary>
-                
-                  ```text
-                  %s
-                  ```
-                
-                </details>
-                """, issue.getDescription());
+                + getMessage(issue)
+                + getStacktrace(issue);
     }
 
     private String getMessage(final TestCase issue) {
         if (issue.getMessage().isBlank()) {
             return StringUtils.EMPTY;
         }
-        return LINE_BREAK_PARAGRAPH + issue.getMessage();
+        return format("""
+                  ```text
+                  %s
+                  ```
+
+                """, issue.getMessage());
+    }
+
+    private String getStacktrace(final TestCase issue) {
+        if (issue.getDescription().isBlank()) {
+            return StringUtils.EMPTY;
+        }
+        return format("""
+                <details>
+                  <summary>Stack Trace</summary>
+                
+                  ```text
+                  %s
+                  ```
+                </details>
+                
+                """, issue.getDescription());
     }
 
     private int sum(final TestScore score, final Function<TestScore, Integer> property) {

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -27,8 +27,9 @@ class AnalysisMarkdownTest {
 
         var writer = new AnalysisMarkdown();
 
-        assertThat(writer.createDetails(aggregation)).contains(TYPE + ": not enabled");
-        assertThat(writer.createSummary(aggregation)).contains(TYPE + ": not enabled");
+        assertThat(writer.createDetails(aggregation, true)).contains(TYPE + ": not enabled");
+        assertThat(writer.createDetails(aggregation)).isEmpty();
+        assertThat(writer.createSummary(aggregation)).isEmpty();
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -59,7 +59,7 @@ class AnalysisMarkdownTest {
                 .contains("Static Analysis Warnings - 100 of 100")
                 .contains("|CheckStyle|0|0|0|0|0|0")
                 .contains(IMPACT_CONFIGURATION);
-        assertThat(analysisMarkdown.createSummary(score))
+        assertThat(analysisMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("CheckStyle - 100 of 100")
                 .contains("No warnings");
     }
@@ -89,7 +89,7 @@ class AnalysisMarkdownTest {
 
         var analysisMarkdown = new AnalysisMarkdown();
 
-        assertThat(analysisMarkdown.createSummary(score)).contains(
+        assertThat(analysisMarkdown.createSummary(score)).hasSize(1).first().asString().contains(
                 "CS - 70 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)");
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("TopLevel Warnings - 70 of 100")
@@ -128,9 +128,11 @@ class AnalysisMarkdownTest {
         var analysisMarkdown = new AnalysisMarkdown();
 
         assertThat(analysisMarkdown.createSummary(score))
-                .contains(
-                        "CheckStyle - 70 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                        "SpotBugs - 80 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                .hasSize(2)
+                .satisfiesExactly(
+                        summary -> assertThat(summary).contains("CheckStyle - 70 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)"),
+                        summary -> assertThat(summary).contains("SpotBugs - 80 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)")
+                );
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("CheckStyle - 50 of 100",
                         "|CheckStyle|1|1|2|3|4|10|-30",
@@ -165,8 +167,11 @@ class AnalysisMarkdownTest {
         var analysisMarkdown = new AnalysisMarkdown();
 
         assertThat(analysisMarkdown.createSummary(score))
-                .contains("CheckStyle: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                        "SpotBugs: 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                .hasSize(2)
+                .satisfiesExactly(
+                        summary -> assertThat(summary).contains("CheckStyle: 10 warnings (error: 1, high: 2, normal: 3, low: 4)"),
+                        summary -> assertThat(summary).contains("SpotBugs: 10 bugs (error: 4, high: 3, normal: 2, low: 1)")
+                );
         assertThat(analysisMarkdown.createDetails(score))
                 .contains("CheckStyle",
                         "|CheckStyle|1|1|2|3|4|10",
@@ -220,11 +225,13 @@ class AnalysisMarkdownTest {
                         ":moneybag:|:heavy_minus_sign:|*1*|*2*|*3*|*4*|:heavy_minus_sign:|:heavy_minus_sign:",
                         ":moneybag:|:heavy_minus_sign:|*-11*|*-12*|*-13*|*-14*|:heavy_minus_sign:|:heavy_minus_sign:");
         assertThat(analysisMarkdown.createSummary(score))
-                .contains("CheckStyle 1 - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                        "CheckStyle 2 - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                        "SpotBugs 1 - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)",
-                        "SpotBugs 2 - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)")
-                .doesNotContain("Total");
+                .hasSize(4)
+                .satisfiesExactly(
+                        summary -> assertThat(summary).contains("CheckStyle 1 - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)"),
+                        summary -> assertThat(summary).contains("CheckStyle 2 - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)"),
+                        summary -> assertThat(summary).contains("SpotBugs 1 - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)"),
+                        summary -> assertThat(summary).contains("SpotBugs 2 - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)")
+                );
     }
 
     static AggregatedScore createScoreForTwoResults() {

--- a/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
@@ -25,15 +25,15 @@ class CoverageMarkdownTest {
         var empty = new AggregatedScore("{}", LOG);
 
         var codeCoverageMarkdown = new CodeCoverageMarkdown();
-        assertThat(codeCoverageMarkdown.createDetails(empty)).contains(
+        assertThat(codeCoverageMarkdown.createDetails(empty, true)).contains(
                 "Code Coverage Score: not enabled");
-        assertThat(codeCoverageMarkdown.createSummary(empty)).contains(
-                "Code Coverage Score: not enabled");
+        assertThat(codeCoverageMarkdown.createDetails(empty)).isEmpty();
+        assertThat(codeCoverageMarkdown.createSummary(empty)).isEmpty();
         var mutationCoverageMarkdown = new MutationCoverageMarkdown();
-        assertThat(mutationCoverageMarkdown.createDetails(empty)).contains(
+        assertThat(mutationCoverageMarkdown.createDetails(empty, true)).contains(
                 "Mutation Coverage Score: not enabled");
-        assertThat(mutationCoverageMarkdown.createSummary(empty)).contains(
-                "Mutation Coverage Score: not enabled");
+        assertThat(mutationCoverageMarkdown.createDetails(empty)).isEmpty();
+        assertThat(mutationCoverageMarkdown.createSummary(empty)).isEmpty();
     }
 
     @Test
@@ -67,7 +67,12 @@ class CoverageMarkdownTest {
         assertThat(codeCoverageMarkdown.createSummary(score))
                 .contains("JaCoCo - 100 of 100: 100% (0 missed lines)");
 
-        assertThat(new MutationCoverageMarkdown().createDetails(score)).contains(
+        verifyEmptyMutationScore(score);
+    }
+
+    private void verifyEmptyMutationScore(final AggregatedScore score) {
+        assertThat(new MutationCoverageMarkdown().createDetails(score)).isEmpty();
+        assertThat(new MutationCoverageMarkdown().createDetails(score, true)).contains(
                 "Mutation Coverage Score: not enabled");
     }
 
@@ -100,8 +105,7 @@ class CoverageMarkdownTest {
                 .doesNotContain("Total");
         assertThat(codeCoverageMarkdown.createSummary(score))
                 .contains("JaCoCo - 20 of 100: 60% (40 missed branches)");
-        assertThat(new MutationCoverageMarkdown().createDetails(score)).contains(
-                "Mutation Coverage Score: not enabled");
+        verifyEmptyMutationScore(score);
     }
 
     static ModuleNode createSampleReport() {
@@ -150,8 +154,7 @@ class CoverageMarkdownTest {
         assertThat(codeCoverageMarkdown.createSummary(score)).contains(
                 "Line Coverage - 60 of 100: 80% (20 missed lines)",
                 "Branch Coverage - 20 of 100: 60% (40 missed branches)");
-        assertThat(new MutationCoverageMarkdown().createDetails(score)).contains(
-                "Mutation Coverage Score: not enabled");
+        verifyEmptyMutationScore(score);
     }
 
     @Test
@@ -191,8 +194,7 @@ class CoverageMarkdownTest {
         assertThat(codeCoverageMarkdown.createSummary(score)).contains(
                 "Line Coverage: 80% (20 missed lines)",
                 "Branch Coverage: 60% (40 missed branches)");
-        assertThat(new MutationCoverageMarkdown().createDetails(score)).contains(
-                "Mutation Coverage Score: not enabled");
+        verifyEmptyMutationScore(score);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
@@ -64,7 +64,7 @@ class CoverageMarkdownTest {
         assertThat(codeCoverageMarkdown.createDetails(score))
                 .contains("Code Coverage - 100 of 100", "|JaCoCo|100|0|100", IMPACT_CONFIGURATION)
                 .doesNotContain("Total");
-        assertThat(codeCoverageMarkdown.createSummary(score))
+        assertThat(codeCoverageMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JaCoCo - 100 of 100: 100% (0 missed lines)");
 
         verifyEmptyMutationScore(score);
@@ -103,7 +103,7 @@ class CoverageMarkdownTest {
         assertThat(codeCoverageMarkdown.createDetails(score))
                 .contains("Code Coverage - 20 of 100", "|JaCoCo|60|40|20", IMPACT_CONFIGURATION)
                 .doesNotContain("Total");
-        assertThat(codeCoverageMarkdown.createSummary(score))
+        assertThat(codeCoverageMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JaCoCo - 20 of 100: 60% (40 missed branches)");
         verifyEmptyMutationScore(score);
     }
@@ -151,9 +151,9 @@ class CoverageMarkdownTest {
                 "|Branch Coverage|60|40|20",
                 "|**Total Ø**|**70**|**30**|**40**",
                 IMPACT_CONFIGURATION);
-        assertThat(codeCoverageMarkdown.createSummary(score)).contains(
-                "Line Coverage - 60 of 100: 80% (20 missed lines)",
-                "Branch Coverage - 20 of 100: 60% (40 missed branches)");
+        assertThat(codeCoverageMarkdown.createSummary(score)).hasSize(2).satisfiesExactly(
+                summary -> assertThat(summary).contains("Line Coverage - 60 of 100: 80% (20 missed lines)"),
+                summary -> assertThat(summary).contains("Branch Coverage - 20 of 100: 60% (40 missed branches)"));
         verifyEmptyMutationScore(score);
     }
 
@@ -191,9 +191,10 @@ class CoverageMarkdownTest {
                         "|**Total Ø**|**70**|**30**")
                 .doesNotContain(IMPACT_CONFIGURATION)
                 .doesNotContain("Impact");
-        assertThat(codeCoverageMarkdown.createSummary(score)).contains(
-                "Line Coverage: 80% (20 missed lines)",
-                "Branch Coverage: 60% (40 missed branches)");
+        assertThat(codeCoverageMarkdown.createSummary(score)).hasSize(2)
+                .satisfiesExactly(
+                        summary -> assertThat(summary).contains("Line Coverage: 80% (20 missed lines)"),
+                        summary -> assertThat(summary).contains("Branch Coverage: 60% (40 missed branches)"));
         verifyEmptyMutationScore(score);
     }
 
@@ -251,16 +252,17 @@ class CoverageMarkdownTest {
                         "|**Total Ø**|**70**|**30**|**40**",
                         IMPACT_CONFIGURATION)
                 .doesNotContain("Mutation Coverage", "PIT");
-        assertThat(codeCoverageMarkdown.createSummary(score)).contains(
-                "Line Coverage - 60 of 100: 80% (20 missed lines)",
-                "Branch Coverage - 20 of 100: 60% (40 missed branches)");
+        assertThat(codeCoverageMarkdown.createSummary(score)).hasSize(2)
+                .satisfiesExactly(
+                        summary -> assertThat(summary).contains("Line Coverage - 60 of 100: 80% (20 missed lines)"),
+                        summary -> assertThat(summary).contains("Branch Coverage - 20 of 100: 60% (40 missed branches)"));
 
         var mutationCoverageMarkdown = new MutationCoverageMarkdown();
         assertThat(mutationCoverageMarkdown.createDetails(score)).contains(
                         "PIT - 20 of 100", IMPACT_CONFIGURATION)
                 .doesNotContain("JaCoCo", "Line Coverage", "Branch Coverage", "Total");
-        assertThat(mutationCoverageMarkdown.createSummary(score)).contains(
-                "Mutation Coverage - 20 of 100: 60% (40 survived mutations)");
+        assertThat(mutationCoverageMarkdown.createSummary(score)).hasSize(1).first().asString()
+                .contains("Mutation Coverage - 20 of 100: 60% (40 survived mutations)");
     }
 
     static ModuleNode createTwoReports(final ToolConfiguration tool) {

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -92,11 +92,17 @@ class GradingReportTest {
         var score = new AggregatedScore();
         assertThat(results.getTextSummary(score)).isEqualTo(
                 "Autograding score");
-        assertThat(results.getMarkdownDetails(score)).contains(
-                "Autograding score",
+        var disabledScores = new String[] {
                 "Unit Tests Score: not enabled",
-                "Coverage Score: not enabled",
-                "Static Analysis Warnings Score: not enabled");
+                "Code Coverage Score: not enabled",
+                "Mutation Coverage Score: not enabled",
+                "Static Analysis Warnings Score: not enabled"};
+        assertThat(results.getMarkdownDetails(score, "Title", true))
+                .contains("Title")
+                .contains(disabledScores);
+        assertThat(results.getMarkdownDetails(score, "Title"))
+                .contains("Title")
+                .doesNotContain(disabledScores);
         assertThat(results.getMarkdownSummary(score, "Summary"))
                 .contains("Summary");
     }
@@ -177,9 +183,6 @@ class GradingReportTest {
                 "Autograding score - 60 of 200 (30%)");
         assertThat(results.getMarkdownDetails(score)).contains(
                 "Autograding score - 60 of 200 (30%)",
-                "Unit Tests Score: not enabled",
-                "Code Coverage Score: not enabled",
-                "Mutation Coverage Score: not enabled",
                 "|CheckStyle 1|1|1|2|3|4|10|30",
                 "|CheckStyle 2|1|1|2|3|4|10|30",
                 "Style - 60 of 100",

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -96,6 +96,7 @@ class TestMarkdownTest {
                 .contains("JUnit - 35 of 100")
                 .contains("|JUnit|3|24|0|13|37|-65")
                 .contains("__Aufgabe3Test:shouldSplitToEmptyRight(int)[1]__")
+                .containsPattern("```text\\n *Expected size: 3 but was: 5 in:")
                 .contains("__edu.hm.hafner.grading.ReportFinderTest:shouldFindTestReports__");
         assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JUnit - 35 of 100", "65 % successful", "13 failed", "24 passed");

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -60,7 +60,7 @@ class TestMarkdownTest {
                 .contains("Tests - 100 of 100")
                 .contains("|JUnit|1|0|0|0|0|0")
                 .contains(":moneybag:|:heavy_minus_sign:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:");
-        assertThat(testMarkdown.createSummary(score))
+        assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .endsWith("Tests - 100 of 100");
     }
 
@@ -97,7 +97,7 @@ class TestMarkdownTest {
                 .contains("|JUnit|3|24|0|13|37|-65")
                 .contains("__Aufgabe3Test:shouldSplitToEmptyRight(int)[1]__")
                 .contains("__edu.hm.hafner.grading.ReportFinderTest:shouldFindTestReports__");
-        assertThat(testMarkdown.createSummary(score))
+        assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JUnit - 35 of 100", "65 % successful", "13 failed", "24 passed");
     }
 
@@ -130,7 +130,7 @@ class TestMarkdownTest {
                 .contains("JUnit - 27 of 100")
                 .contains("|JUnit|1|5|3|4|12|27")
                 .contains(IMPACT_CONFIGURATION);
-        assertThat(testMarkdown.createSummary(score))
+        assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JUnit - 27 of 100", "42 % successful", "4 failed", "5 passed", "3 skipped");
     }
 
@@ -173,7 +173,7 @@ class TestMarkdownTest {
                         "- test-class-skipped-0#test-skipped-0",
                         "- test-class-skipped-1#test-skipped-1",
                         "- test-class-skipped-2#test-skipped-2");
-        assertThat(testMarkdown.createSummary(score))
+        assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JUnit - 77 of 100", "23 % successful", "14 failed", "5 passed", "3 skipped");
     }
 
@@ -213,7 +213,7 @@ class TestMarkdownTest {
                         "- test-class-skipped-2#test-skipped-2")
                 .doesNotContain(IMPACT_CONFIGURATION)
                 .doesNotContain("Impact");
-        assertThat(testMarkdown.createSummary(score))
+        assertThat(testMarkdown.createSummary(score)).hasSize(1).first().asString()
                 .contains("JUnit", "23 %", "14 failed", "5 passed", "3 skipped");
     }
 
@@ -305,12 +305,12 @@ class TestMarkdownTest {
                         "```text StackTrace-0```",
                         "```text StackTrace-1```",
                         "```text StackTrace-2```");
-        assertThat(testMarkdown.createSummary(score))
-                .containsIgnoringWhitespaces(
-                        "One - 46 of 100", "42 % successful",
-                        "8 failed", "10 passed", "6 skipped",
-                        "Two - 40 of 100", "0 % successful",
-                        "20 failed");
+        assertThat(testMarkdown.createSummary(score)).hasSize(2)
+                .satisfiesExactly(
+                        summary -> assertThat(summary)
+                                .contains("One - 46 of 100", "42 % successful", "8 failed", "10 passed", "6 skipped"),
+                        summary -> assertThat(summary)
+                                .contains("Two - 40 of 100", "0 % successful", "20 failed"));
     }
 
     @Test


### PR DESCRIPTION
Showing disabled scores is good for debugging but not for the actual evaluation of projects, so it makes sense to hide these elements.

Additionally, line breaks in unit tests and summaries were still broken and should be fixed now.