### PR TITLE
Add support for software metrics

### DIFF
--- a/.github/workflows/quality-monitor.yml
+++ b/.github/workflows/quality-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         id: pr
       - name: Run Quality Monitor
-        uses: uhafner/quality-monitor@v1
+        uses: uhafner/quality-monitor@v1.12.0-beta-1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}
@@ -65,7 +65,7 @@ jobs:
                     },
                     {
                       "id": "pmd",
-                      "pattern": "**/target/**pmd.xml"
+                      "pattern": "**/target/pmd-*/pmd.xml"
                     }
                   ]
                 },
@@ -126,6 +126,44 @@ jobs:
                       "metric": "mutation",
                       "sourcePath": "src/main/java",
                       "pattern": "**/target/pit-reports/mutations.xml"
+                    },
+                    {
+                      "id": "pit",
+                      "name": "Test Strength",
+                      "metric": "test-strength",
+                      "sourcePath": "src/main/java",
+                      "pattern": "**/target/pit-reports/mutations.xml"
+                    }
+                  ]
+                }
+              ],
+              "metrics": [
+                {
+                  "name": "Toplevel Metrics",
+                  "tools": [
+                    {
+                      "name": "Cyclomatic Complexity",
+                      "id": "metrics",
+                      "pattern": "**/metrics/pmd.xml",
+                      "metric": "CyclomaticComplexity"
+                    },
+                    {
+                      "name": "Cognitive Complexity",
+                      "id": "metrics",
+                      "pattern": "**/metrics/pmd.xml",
+                      "metric": "CognitiveComplexity"
+                    },
+                    {
+                      "name": "Non Commenting Source Statements",
+                      "id": "metrics",
+                      "pattern": "**/metrics/pmd.xml",
+                      "metric": "NCSS"
+                    },
+                    {
+                      "name": "N-Path Complexity",
+                      "id": "metrics",
+                      "pattern": "**/metrics/pmd.xml",
+                      "metric": "NPathComplexity"
                     }
                   ]
                 }

--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -27,21 +27,11 @@ jobs:
       - name: Build and test with Maven
         run: mvn -V --color always -ntp clean verify -Pci -Ppit -Pdepgraph | tee maven.log
       - name: Run Quality Monitor
-        uses: uhafner/quality-monitor@v1
+        uses: uhafner/quality-monitor@v1.12.0-beta-1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: >
             {
-            "tests": {
-              "tools": [
-                {
-                  "id": "test",
-                  "name": "Tests",
-                  "pattern": "**/target/*-reports/TEST*.xml"
-                }
-              ],
-              "name": "Tests"
-            },
             "analysis": [
               {
                 "name": "Style",
@@ -72,6 +62,17 @@ jobs:
                     "pattern": "**/maven.log"
                   }
                 ]
+                },
+                {
+                  "name": "Vulnerabilities",
+                  "id": "vulnerabilities",
+                  "icon": "shield",
+                  "tools": [
+                    {
+                      "id": "owasp-dependency-check",
+                      "pattern": "**/target/dependency-check-report.json"                    
+                    }
+                  ]
               }
             ],
             "coverage": [

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>edu.hm.hafner</groupId>
     <artifactId>codingstyle-pom</artifactId>
-    <version>4.16.0</version>
+    <version>5.2.0</version>
     <relativePath />
   </parent>
 
@@ -58,9 +58,7 @@
 
     <jackson-databind.version>2.18.0</jackson-databind.version>
     <analysis-model.version>12.9.0</analysis-model.version>
-    <coverage-model.version>0.47.0</coverage-model.version>
-    <java.version>17</java.version>
-
+    <coverage-model.version>0.48.0</coverage-model.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -15,6 +15,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.registry.ParserDescriptor.Type;
 import edu.hm.hafner.analysis.registry.ParserRegistry;
 import edu.hm.hafner.util.Ensure;
 import edu.hm.hafner.util.Generated;
@@ -164,6 +165,14 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
     }
 
     private String getItemCount(final int count) {
+        if (REGISTRY.contains(getId())) {
+            if (REGISTRY.get(getId()).getType() == Type.VULNERABILITY) {
+                if (count == 1) {
+                    return "vulnerability";
+                }
+                return "vulnerabilities";
+            }
+        }
         return getItemName() + plural(count);
     }
 

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -165,13 +165,12 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
     }
 
     private String getItemCount(final int count) {
-        if (REGISTRY.contains(getId())) {
-            if (REGISTRY.get(getId()).getType() == Type.VULNERABILITY) {
-                if (count == 1) {
-                    return "vulnerability";
-                }
-                return "vulnerabilities";
+        if (REGISTRY.contains(getId())
+                && REGISTRY.get(getId()).getType() == Type.VULNERABILITY) {
+            if (count == 1) {
+                return "vulnerability";
             }
+            return "vulnerabilities";
         }
         return getItemName() + plural(count);
     }

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -96,6 +96,11 @@ public class AutoGradingRunner {
             logHandler.print();
 
             log.logInfo(DOUBLE_LINE);
+
+            score.gradeMetrics(new FileSystemCoverageReportFactory());
+            logHandler.print();
+
+            log.logInfo(DOUBLE_LINE);
             var results = new GradingReport();
             log.logInfo(results.getTextSummary(score));
             log.logInfo(DOUBLE_LINE);
@@ -215,7 +220,7 @@ public class AutoGradingRunner {
         if (log.hasErrors()) {
             var errors = new StringBuilder(ERROR_CAPACITY);
 
-            errors.append("\n### :construction: Error Messages\n\n```\n");
+            errors.append("\n### :construction: &nbsp; Error Messages\n\n```\n");
             var messages = new StringJoiner("\n");
             log.getErrorMessages().forEach(messages::add);
             errors.append(messages);

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -58,7 +58,7 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         else {
             this.metric = metrics.iterator().next();
         }
-        this.icon = selectIcon(this.metric);
+        this.icon = selectIcon();
 
         this.report = new ContainerNode(name);
         scores.stream().map(CoverageScore::getReport).forEach(report::addChild);
@@ -70,7 +70,7 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
 
         this.report = report;
         this.metric = metric;
-        this.icon = selectIcon(metric);
+        this.icon = selectIcon();
 
         var value = report.getValue(metric);
         if (value.isPresent() && value.get() instanceof Coverage) {
@@ -91,8 +91,8 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         return icon;
     }
 
-    private String selectIcon(final Metric iconMetric) {
-        switch (iconMetric) {
+    private String selectIcon() {
+        switch (metric) {
             case BRANCH -> {
                 return "curly_loop";
             }

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -31,6 +31,8 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
     @Serial
     private static final long serialVersionUID = 3L;
 
+    private static final Metric AGGREGATION_METRIC = Metric.CONTAINER;
+
     private final int coveredPercentage;
     private final Metric metric;
     private final String icon;
@@ -44,19 +46,19 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         this.coveredPercentage = scores.stream()
                 .reduce(0, (sum, score) -> sum + score.getCoveredPercentage(), Integer::sum)
                 / scores.size();
+        this.missedItems = scores.stream()
+                .reduce(0, (sum, score) -> sum + score.getMissedItems(), Integer::sum);
         var metrics = scores.stream()
                 .map(CoverageScore::getMetric)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
-        this.missedItems = scores.stream()
-                .reduce(0, (sum, score) -> sum + score.getMissedItems(), Integer::sum);
         if (metrics.size() > 1) {
-            this.metric = Metric.FILE;
+            this.metric = AGGREGATION_METRIC; // cannot aggregate different metrics
         }
         else {
             this.metric = metrics.iterator().next();
         }
-        this.icon = selectIcon(Metric.FILE);
+        this.icon = selectIcon(this.metric);
 
         this.report = new ContainerNode(name);
         scores.stream().map(CoverageScore::getReport).forEach(report::addChild);
@@ -97,11 +99,14 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
             case LINE -> {
                 return "wavy_dash";
             }
-            case COMPLEXITY -> {
+            case CYCLOMATIC_COMPLEXITY -> {
                 return "part_alternation_mark";
             }
             case LOC -> {
                 return "pencil2";
+            }
+            case TEST_STRENGTH ->  {
+                return "muscle";
             }
             default -> {
                 return "footprints";
@@ -165,19 +170,22 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
             case MUTATION -> {
                 return "survived mutations";
             }
+            case TEST_STRENGTH -> {
+                return "survived mutations in tested code";
+            }
             case BRANCH -> {
                 return "missed branches";
             }
             case LINE -> {
                 return "missed lines";
             }
-            case COMPLEXITY -> {
+            case CYCLOMATIC_COMPLEXITY -> {
                 return "complexity";
             }
             case LOC -> {
                 return "lines of code";
             }
-            case FILE -> {
+            case CONTAINER -> {
                 return "missed items";
             }
             default -> {
@@ -294,6 +302,9 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         public CoverageScoreBuilder withReport(final Node rootNode, final Metric metric) {
             this.report = rootNode;
             this.metric = metric;
+
+            Ensure.that(metric.isCoverage()).isTrue("The metric must be a coverage metric, but is %s", metric);
+
             return this;
         }
 

--- a/src/main/java/edu/hm/hafner/grading/FileSystemCoverageReportFactory.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemCoverageReportFactory.java
@@ -64,8 +64,8 @@ public final class FileSystemCoverageReportFactory implements CoverageReportFact
         return new ContainerNode(tool.getName());
     }
 
-    private String extractMetric(final ToolConfiguration tool, final Node node) {
-        return node.getValue(Metric.valueOf(StringUtils.upperCase(tool.getMetric())))
+    String extractMetric(final ToolConfiguration tool, final Node node) {
+        return node.getValue(Metric.fromName(tool.getMetric()))
                 .map(Value::toString)
                 .orElse("<none>");
     }

--- a/src/main/java/edu/hm/hafner/grading/FileSystemMetricReportFactory.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemMetricReportFactory.java
@@ -1,0 +1,31 @@
+package edu.hm.hafner.grading;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.grading.AggregatedScore.CoverageReportFactory;
+import edu.hm.hafner.util.FilteredLog;
+
+/**
+ * Reads metric reports of a specific type from the file system and creates an aggregated report.
+ *
+ * @author Ullrich Hafner
+ */
+public final class FileSystemMetricReportFactory implements CoverageReportFactory {
+    @Override
+    public Node create(final ToolConfiguration tool, final FilteredLog log) {
+        var name = StringUtils.defaultIfBlank(tool.getName(), "Software Metrics");
+
+        var delegate = new FileSystemCoverageReportFactory();
+        var report = delegate.create(new ToolConfiguration("metrics", name, tool.getPattern(), "", "Metric"), log);
+
+        var metricName = delegate.extractMetric(tool, report);
+        var metric = Metric.fromTag(metricName);
+        log.logInfo("-> %s: %s",
+                metricName, report.getValue(metric).orElse(Value.nullObject(metric)));
+
+        return report;
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/FileSystemTestReportFactory.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemTestReportFactory.java
@@ -4,8 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Node;
-import edu.hm.hafner.coverage.TestCount;
-import edu.hm.hafner.grading.AggregatedScore.TestReportFactory;
+import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.grading.AggregatedScore.CoverageReportFactory;
 import edu.hm.hafner.util.FilteredLog;
 
 /**
@@ -13,7 +13,7 @@ import edu.hm.hafner.util.FilteredLog;
  *
  * @author Ullrich Hafner
  */
-public final class FileSystemTestReportFactory implements TestReportFactory {
+public final class FileSystemTestReportFactory implements CoverageReportFactory {
     @Override
     public Node create(final ToolConfiguration tool, final FilteredLog log) {
         var name = StringUtils.defaultIfBlank(tool.getName(), "Tests");
@@ -22,7 +22,7 @@ public final class FileSystemTestReportFactory implements TestReportFactory {
         var report = delegate.create(new ToolConfiguration("junit", name, tool.getPattern(), "", Metric.TESTS.name()), log);
 
         log.logInfo("-> %s Total: %s tests",
-                name, report.getValue(Metric.TESTS).orElse(new TestCount(0)));
+                name, report.getValue(Metric.TESTS).orElse(Value.nullObject(Metric.TESTS)));
 
         return report;
     }

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -17,6 +17,7 @@ public class GradingReport {
     private static final AnalysisMarkdown ANALYSIS_MARKDOWN = new AnalysisMarkdown();
     private static final CodeCoverageMarkdown CODE_COVERAGE_MARKDOWN = new CodeCoverageMarkdown();
     private static final MutationCoverageMarkdown MUTATION_COVERAGE_MARKDOWN = new MutationCoverageMarkdown();
+    private static final MetricMarkdown METRIC_MARKDOWN = new MetricMarkdown();
     private static final String DEFAULT_TITLE = "Autograding score";
     private static final String PARAGRAPH = ScoreMarkdown.PARAGRAPH;
 
@@ -98,6 +99,7 @@ public class GradingReport {
         items.addAll(CODE_COVERAGE_MARKDOWN.createSummary(score));
         items.addAll(MUTATION_COVERAGE_MARKDOWN.createSummary(score));
         items.addAll(ANALYSIS_MARKDOWN.createSummary(score));
+        items.addAll(METRIC_MARKDOWN.createSummary(score));
 
         summary.append(createPercentage(score, items.size()));
         summary.append(String.join(ScoreMarkdown.LINE_BREAK_PARAGRAPH, items));
@@ -148,7 +150,8 @@ public class GradingReport {
                 + TEST_MARKDOWN.createDetails(score, showDisabled)
                 + ANALYSIS_MARKDOWN.createDetails(score, showDisabled)
                 + CODE_COVERAGE_MARKDOWN.createDetails(score, showDisabled)
-                + MUTATION_COVERAGE_MARKDOWN.createDetails(score, showDisabled);
+                + MUTATION_COVERAGE_MARKDOWN.createDetails(score, showDisabled)
+                + METRIC_MARKDOWN.createDetails(score, showDisabled);
     }
 
     private String createMarkdownTotal(final AggregatedScore score, final String title, final int size) {

--- a/src/main/java/edu/hm/hafner/grading/MetricConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricConfiguration.java
@@ -1,0 +1,58 @@
+package edu.hm.hafner.grading;
+
+import java.io.Serial;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Configuration to grade software metrics. The configuration specifies the impact of the software metrics results
+ * on the score. This class is intended to be deserialized from JSON, there is no public constructor available.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("unused")
+public final class MetricConfiguration extends Configuration {
+    @Serial
+    private static final long serialVersionUID = 3L;
+
+    private static final String METRICS_ID = "metrics";
+
+    /**
+     * Converts the specified JSON object to a list of {@link MetricConfiguration} instances.
+     *
+     * @param json
+     *         the JSON object to convert
+     *
+     * @return the corresponding {@link MetricConfiguration} instances
+     */
+    public static List<MetricConfiguration> from(final String json) {
+        return extractConfigurations(json, METRICS_ID, MetricConfiguration.class);
+    }
+
+    private MetricConfiguration() {
+        super(); // Instances are created via JSON deserialization
+    }
+
+    @Override
+    protected String getDefaultId() {
+        return METRICS_ID;
+    }
+
+    @Override
+    protected String getDefaultName() {
+        return "Metrics";
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isPositive() {
+        return true;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean hasImpact() {
+        return false;
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/MetricMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricMarkdown.java
@@ -1,0 +1,69 @@
+package edu.hm.hafner.grading;
+
+import java.util.List;
+
+import edu.hm.hafner.grading.TruncatedString.TruncatedStringBuilder;
+
+/**
+ * Renders the static analysis results in Markdown.
+ *
+ * @author Tobias Effner
+ * @author Ullrich Hafner
+ */
+public class MetricMarkdown extends ScoreMarkdown<MetricScore, MetricConfiguration> {
+    static final String TYPE = "Metrics Score";
+    private static final String METRIC_ICON = "triangular_ruler";
+
+    /**
+     * Creates a new Markdown renderer for static analysis results.
+     */
+    public MetricMarkdown() {
+        super(TYPE, METRIC_ICON);
+    }
+
+    @Override
+    protected List<MetricScore> createScores(final AggregatedScore aggregation) {
+        return aggregation.getMetricScores();
+    }
+
+    @Override
+    protected void createSpecificDetails(final AggregatedScore aggregation, final List<MetricScore> scores,
+            final TruncatedStringBuilder details) {
+        for (MetricScore score : scores) {
+            details.addText(getTitle(score, 2))
+                    .addParagraph()
+                    .addText(getPercentageImage(score))
+                    .addNewline()
+                    .addText(formatColumns("Name", "Value"))
+                    .addTextIf(formatColumns("Impact"), score.hasMaxScore())
+                    .addNewline()
+                    .addText(formatColumns(":-:", ":-:"))
+                    .addTextIf(formatColumns(":-:"), score.hasMaxScore())
+                    .addNewline();
+
+            score.getSubScores().forEach(subScore -> details
+                    .addText(formatColumns(subScore.getName(), subScore.createSummary()))
+                    .addTextIf(formatColumns(String.valueOf(subScore.getImpact())), score.hasMaxScore())
+                    .addNewline());
+
+            details.addNewline();
+        }
+    }
+
+    @Override
+    protected List<String> createSummary(final MetricScore score) {
+        return score.getSubScores().stream()
+                .map(s -> SPACE + SPACE + getTitle(s, 0) + ": " + s.createSummary()).toList();
+    }
+
+    @Override
+    protected String getIcon(final MetricScore score) {
+        return switch (score.getMetric()) {
+            case CYCLOMATIC_COMPLEXITY -> ":cyclone:";
+            case NCSS -> ":memo:";
+            case COGNITIVE_COMPLEXITY -> ":bulb:";
+            case NPATH_COMPLEXITY -> ":loop:";
+            default -> super.getIcon(score);
+        };
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/MetricScore.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricScore.java
@@ -1,0 +1,240 @@
+package edu.hm.hafner.grading;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+import edu.hm.hafner.coverage.ContainerNode;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.util.Ensure;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+/**
+ * Computes the {@link Score} impact of software metrics.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("PMD.DataClass")
+public final class MetricScore extends Score<MetricScore, MetricConfiguration> {
+    @Serial
+    private static final long serialVersionUID = 3L;
+
+    private static final String N_A = "<n/a>";
+    private static final Metric AGGREGATION_METRIC = Metric.CONTAINER;
+
+    private transient Node report; // do not persist the metrics tree
+    private final Metric metric;
+
+    private MetricScore(final String id, final String name, final MetricConfiguration configuration,
+            final List<MetricScore> scores) {
+        super(id, name, configuration, scores.toArray(new MetricScore[0]));
+
+        this.report = new ContainerNode(name);
+
+        var metrics = scores.stream()
+                .map(MetricScore::getMetric)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (metrics.size() > 1) {
+            this.metric = AGGREGATION_METRIC; // cannot aggregate different metrics
+        }
+        else {
+            this.metric = metrics.iterator().next();
+        }
+
+        scores.stream().map(MetricScore::getReport).forEach(report::addChild);
+    }
+
+    private MetricScore(final String id, final String name, final MetricConfiguration configuration,
+            final Node report, final Metric metric) {
+        super(id, name, configuration);
+
+        this.report = report;
+        this.metric = metric;
+    }
+
+    /**
+     * Restore an empty report after de-serialization.
+     *
+     * @return this
+     */
+    @Serial @CanIgnoreReturnValue
+    private Object readResolve() {
+        report = new ModuleNode("empty");
+
+        return this;
+    }
+
+    public Metric getMetric() {
+        return metric;
+    }
+
+    /**
+     * Returns the value of the metric as an integer.
+     *
+     * @return the value of the metric
+     */
+    public int getMetricValue() {
+        return getReport().getValue(metric)
+                .map(Value::asInteger)
+                .orElse(0);
+    }
+
+    public String getMetricTagName() {
+        return metric.toTagName();
+    }
+
+    @Override
+    public int getImpact() {
+        return 0;
+    }
+
+    @JsonIgnore
+    public Node getReport() {
+        return ObjectUtils.defaultIfNull(report, new ModuleNode("empty"));
+    }
+
+    @Override
+    protected String createSummary() {
+        if (metric == AGGREGATION_METRIC) {
+            return N_A; // there is no aggregated value for multiple metrics
+        }
+        return getReport().getValue(metric)
+                .map(Value::asText)
+                .orElse(N_A);
+    }
+
+    /**
+     * A builder for {@link MetricScore} instances.
+     */
+    @SuppressWarnings({"checkstyle:HiddenField", "ParameterHidesMemberVariable"})
+    public static class MetricScoreBuilder {
+        @CheckForNull
+        private String id;
+        @CheckForNull
+        private String name;
+        @CheckForNull
+        private MetricConfiguration configuration;
+
+        private final List<MetricScore> scores = new ArrayList<>();
+        @CheckForNull
+        private Metric metric;
+        @CheckForNull
+        private Node report;
+
+        /**
+         * Sets the ID of the metric score.
+         *
+         * @param id
+         *         the ID
+         *
+         * @return this
+         */
+        @CanIgnoreReturnValue
+        public MetricScoreBuilder withId(final String id) {
+            this.id = id;
+            return this;
+        }
+
+        private String getId() {
+            return StringUtils.defaultIfBlank(id, getConfiguration().getId());
+        }
+
+        /**
+         * Sets the human-readable name of the metric score.
+         *
+         * @param name
+         *         the name to show
+         *
+         * @return this
+         */
+        @CanIgnoreReturnValue
+        public MetricScoreBuilder withName(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        private String getName() {
+            return StringUtils.defaultIfBlank(name, getConfiguration().getName());
+        }
+
+        /**
+         * Sets the grading configuration.
+         *
+         * @param configuration
+         *         the grading configuration
+         *
+         * @return this
+         */
+        @CanIgnoreReturnValue
+        public MetricScoreBuilder withConfiguration(final MetricConfiguration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        private MetricConfiguration getConfiguration() {
+            return Objects.requireNonNull(configuration);
+        }
+
+        /**
+         * Sets the scores that should be aggregated by this score.
+         *
+         * @param scores
+         *         the scores to aggregate
+         *
+         * @return this
+         */
+        @CanIgnoreReturnValue
+        public MetricScoreBuilder withScores(final List<MetricScore> scores) {
+            Ensure.that(scores).isNotEmpty("You cannot add an empty list of scores.");
+            this.scores.clear();
+            this.scores.addAll(scores);
+
+            return this;
+        }
+
+        /**
+         * Sets the report with the issues that should be evaluated by this score.
+         *
+         * @param report
+         *         the issues to evaluate
+         * @param metric
+         *        the metric to use
+         * @return this
+         */
+        @CanIgnoreReturnValue
+        public MetricScoreBuilder withReport(final Node report, final Metric metric) {
+            this.report = report;
+            this.metric = metric;
+
+            return this;
+        }
+
+        /**
+         * Builds the {@link MetricScore} instance with the configured values.
+         *
+         * @return the new instance
+         */
+        public MetricScore build() {
+            Ensure.that(report != null ^ !scores.isEmpty()).isTrue(
+                    "You must either specify a metric report or provide a list of sub-scores.");
+
+            if (report == null || metric == null) {
+                return new MetricScore(getId(), getName(), getConfiguration(), scores);
+            }
+            return new MetricScore(getId(), getName(), getConfiguration(),
+                    Objects.requireNonNull(report), Objects.requireNonNull(metric));
+        }
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/MutationCoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/MutationCoverageMarkdown.java
@@ -2,6 +2,8 @@ package edu.hm.hafner.grading;
 
 import java.util.List;
 
+import edu.hm.hafner.coverage.Metric;
+
 /**
  * Renders the mutation coverage results in Markdown.
  *
@@ -26,7 +28,7 @@ public class MutationCoverageMarkdown extends CoverageMarkdown {
 
     @Override
     protected String getIcon(final CoverageScore score) {
-        if (PIT.equals(score.getId())) {
+        if (PIT.equals(score.getId()) && score.getMetric() == Metric.MUTATION) { // override icon for PIT
             return format("<img src=\"https://pitest.org/images/pit-black-150x152.png\" alt=\"PIT\" height=\"%d\" width=\"%d\">",
                     ICON_SIZE, ICON_SIZE);
         }

--- a/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
@@ -204,7 +204,38 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
                 "coveredPercentageImpact": 1,
                 "missedPercentageImpact": -1
               }
-              ]
+              ],
+            "metrics": [
+              {
+                "name": "Toplevel Metrics",
+                "tools": [
+                  {
+                    "name": "Cyclomatic Complexity",
+                    "id": "metrics",
+                    "pattern": "**/src/**/metrics.xml",
+                    "metric": "CyclomaticComplexity"
+                  },
+                  {
+                    "name": "Cognitive Complexity",
+                    "id": "metrics",
+                    "pattern": "**/src/**/metrics.xml",
+                    "metric": "CognitiveComplexity"
+                  },
+                  {
+                    "name": "Non Commenting Source Statements",
+                    "id": "metrics",
+                    "pattern": "**/src/**/metrics.xml",
+                    "metric": "NCSS"
+                  },
+                  {
+                    "name": "N-Path Complexity",
+                    "id": "metrics",
+                    "pattern": "**/src/**/metrics.xml",
+                    "metric": "NPathComplexity"
+                  }
+                ]
+              }
+            ]
             }
             """;
 
@@ -376,14 +407,37 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
                 .hasAnalysisAchievedScore(30)
                 .hasToString("Score: 167 / 500");
 
+        aggregation.gradeMetrics((tool, log) -> MetricMarkdownTest.createNodes(tool));
+
+        assertThat(aggregation)
+                .hasAchievedScore(167)
+                .hasTestAchievedScore(77)
+                .hasCoverageAchievedScore(60)
+                .hasCoverage()
+                .hasCoverageRatio(30)
+                .hasCodeCoverageAchievedScore(40)
+                .hasCodeCoverage()
+                .hasCodeCoverageRatio(40)
+                .hasMutationCoverageAchievedScore(20)
+                .hasMutationCoverage()
+                .hasMutationCoverageAchievedScore(20)
+                .hasAnalysisAchievedScore(30)
+                .hasToString("Score: 167 / 500");
+
         assertThat(logger.getErrorMessages()).isEmpty();
         assertThat(String.join("\n", logger.getInfoMessages())).contains(
-                "Processing 2 coverage configuration(s)",
-                "=> JaCoCo Score: 40 of 100",
-                "=> PIT Score: 20 of 100"
+                "Processing 1 metric configuration(s)",
+                "=> Cyclomatic Complexity: 10",
+                "=> Cognitive Complexity: 100",
+                "=> Non Commenting Source Statements: <n/a>",
+                "=> N-Path Complexity: <n/a>"
         );
 
         assertThat(aggregation.getMetrics()).containsOnly(
+                entry("cyclomatic-complexity", 10),
+                entry("ncss", 0),
+                entry("npath-complexity", 0),
+                entry("cognitive-complexity", 100),
                 entry("tests", 22),
                 entry("branch", 60),
                 entry("line", 80),
@@ -446,6 +500,8 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
                         "analysisScores.subScores.report",
                         "coverageScores.report",
                         "coverageScores.subScores.report",
+                        "metricScores.report",
+                        "metricScores.subScores.report",
                         "testScores.report",
                         "testScores.subScores.report")
                 .isEqualTo(original);

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -22,98 +22,130 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class AutoGradingRunnerITest extends ResourceTest {
     private static final String CONFIGURATION = """
-            {
-              "tests": {
-                "tools": [
                   {
-                    "id": "test",
-                    "name": "Unittests",
-                    "pattern": "**/src/**/TEST*.xml"
-                  }
-                ],
-                "name": "JUnit",
-                "passedImpact": 10,
-                "skippedImpact": -1,
-                "failureImpact": -5,
-                "maxScore": 100
-              },
-              "analysis": [
-                {
-                  "name": "Style",
-                  "id": "style",
-                  "tools": [
-                    {
-                      "id": "checkstyle",
-                      "name": "CheckStyle",
-                      "pattern": "**/src/**/checkstyle*.xml"
+                    "tests": {
+                      "tools": [
+                        {
+                          "id": "test",
+                          "name": "Unittests",
+                          "pattern": "**/src/**/TEST*.xml"
+                        }
+                      ],
+                      "name": "JUnit",
+                      "passedImpact": 10,
+                      "skippedImpact": -1,
+                      "failureImpact": -5,
+                      "maxScore": 100
                     },
-                    {
-                      "id": "pmd",
-                      "name": "PMD",
-                      "pattern": "**/src/**/pmd*.xml"
-                    }
-                  ],
-                  "errorImpact": 1,
-                  "highImpact": 2,
-                  "normalImpact": 3,
-                  "lowImpact": 4,
-                  "maxScore": 100
-                },
-                {
-                  "name": "Bugs",
-                  "id": "bugs",
-                  "tools": [
-                    {
-                      "id": "spotbugs",
-                      "name": "SpotBugs",
-                      "pattern": "**/src/**/spotbugs*.xml"
-                    }
-                  ],
-                  "errorImpact": -11,
-                  "highImpact": -12,
-                  "normalImpact": -13,
-                  "lowImpact": -14,
-                  "maxScore": 100
-                }
-              ],
-              "coverage": [
-              {
-                  "tools": [
+                    "analysis": [
                       {
-                        "id": "jacoco",
-                        "name": "Line Coverage",
-                        "metric": "line",
-                        "pattern": "**/src/**/jacoco.xml"
+                        "name": "Style",
+                        "id": "style",
+                        "tools": [
+                          {
+                            "id": "checkstyle",
+                            "name": "CheckStyle",
+                            "pattern": "**/src/**/checkstyle*.xml"
+                          },
+                          {
+                            "id": "pmd",
+                            "name": "PMD",
+                            "pattern": "**/src/**/pmd*.xml"
+                          }
+                        ],
+                        "errorImpact": 1,
+                        "highImpact": 2,
+                        "normalImpact": 3,
+                        "lowImpact": 4,
+                        "maxScore": 100
                       },
                       {
-                        "id": "jacoco",
-                        "name": "Branch Coverage",
-                        "metric": "branch",
-                        "pattern": "**/src/**/jacoco.xml"
+                        "name": "Bugs",
+                        "id": "bugs",
+                        "tools": [
+                          {
+                            "id": "spotbugs",
+                            "name": "SpotBugs",
+                            "pattern": "**/src/**/spotbugs*.xml"
+                          }
+                        ],
+                        "errorImpact": -11,
+                        "highImpact": -12,
+                        "normalImpact": -13,
+                        "lowImpact": -14,
+                        "maxScore": 100
                       }
                     ],
-                "name": "JaCoCo",
-                "maxScore": 100,
-                "coveredPercentageImpact": 1,
-                "missedPercentageImpact": -1
-              },
-              {
-                  "tools": [
+                    "coverage": [
                       {
-                        "id": "pit",
-                        "name": "Mutation Coverage",
-                        "metric": "mutation",
-                        "pattern": "**/src/**/mutations.xml"
+                        "tools": [
+                          {
+                            "id": "jacoco",
+                            "name": "Line Coverage",
+                            "metric": "line",
+                            "pattern": "**/src/**/jacoco.xml"
+                          },
+                          {
+                            "id": "jacoco",
+                            "name": "Branch Coverage",
+                            "metric": "branch",
+                            "pattern": "**/src/**/jacoco.xml"
+                          }
+                        ],
+                        "name": "JaCoCo",
+                        "maxScore": 100,
+                        "coveredPercentageImpact": 1,
+                        "missedPercentageImpact": -1
+                      },
+                      {
+                        "tools": [
+                          {
+                            "id": "pit",
+                            "name": "Mutation Coverage",
+                            "metric": "mutation",
+                            "pattern": "**/src/**/mutations.xml"
+                          }
+                        ],
+                        "name": "PIT",
+                        "maxScore": 100,
+                        "coveredPercentageImpact": 1,
+                        "missedPercentageImpact": -1
                       }
                     ],
-                "name": "PIT",
-                "maxScore": 100,
-                "coveredPercentageImpact": 1,
-                "missedPercentageImpact": -1
-              }
-              ]
-            }
+                    "metrics": [
+                      {
+                        "name": "Toplevel Metrics",
+                        "tools": [
+                          {
+                            "name": "Cyclomatic Complexity",
+                            "id": "metrics",
+                            "pattern": "**/src/**/metrics.xml",
+                            "metric": "CyclomaticComplexity"
+                          },
+                          {
+                            "name": "Cognitive Complexity",
+                            "id": "metrics",
+                            "pattern": "**/src/**/metrics.xml",
+                            "metric": "CognitiveComplexity"
+                          },
+                          {
+                            "name": "Non Commenting Source Statements",
+                            "id": "metrics",
+                            "pattern": "**/src/**/metrics.xml",
+                            "metric": "NCSS"
+                          },
+                          {
+                            "name": "N-Path Complexity",
+                            "id": "metrics",
+                            "pattern": "**/src/**/metrics.xml",
+                            "metric": "NPathComplexity"
+                          }
+                        ]
+                      }
+                    ]
+                  }
             """;
+
     private static final String CONFIGURATION_WRONG_PATHS = """
             {
               "tests": {
@@ -232,11 +264,16 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "=> Style Score: 18 of 100",
                         "-> SpotBugs Total: 2 warnings",
                         "=> Bugs Score: 72 of 100",
-                        "Autograding score - 226 of 500"});
+                        "=> Cyclomatic Complexity: 355",
+                        "=> Cognitive Complexity: 172",
+                        "=> Non Commenting Source Statements: 1200",
+                        "=> N-Path Complexity: 432",
+                        "Autograding score - 226 of 500 (45%)"});
 
         var builder = new StringCommentBuilder();
         builder.createAnnotations(score);
-        assertThat(builder.getComments()).contains("[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:17-17: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
+        assertThat(builder.getComments()).contains(
+                "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:17-17: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:42-42: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:22-22: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:29-29: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
@@ -274,7 +311,8 @@ public class AutoGradingRunnerITest extends ResourceTest {
         return outputStream.toString(StandardCharsets.UTF_8);
     }
 
-    @Test @SetEnvironmentVariable(key = "CONFIG", value = CONFIGURATION_WRONG_PATHS)
+    @Test
+    @SetEnvironmentVariable(key = "CONFIG", value = CONFIGURATION_WRONG_PATHS)
     void shouldShowErrors() {
         assertThat(runAutoGrading())
                 .contains(new String[] {
@@ -307,7 +345,7 @@ public class AutoGradingRunnerITest extends ResourceTest {
         log.logError("This is an error");
         assertThat(runner.createErrorMessageMarkdown(log))
                 .startsWith("\n")
-                .contains("## :construction: Error Messages")
+                .contains("## :construction: &nbsp; Error Messages")
                 .contains("This is an error");
     }
 
@@ -320,7 +358,8 @@ public class AutoGradingRunnerITest extends ResourceTest {
         assertThat(runner.getConfiguration(log))
                 .contains(toString("/default-config.json"));
         assertThat(log.getInfoMessages())
-                .contains("No configuration provided (environment variable CONFIG not set), using default configuration");
+                .contains(
+                        "No configuration provided (environment variable CONFIG not set), using default configuration");
         assertThat(log.getErrorMessages()).isEmpty();
     }
 
@@ -343,11 +382,15 @@ public class AutoGradingRunnerITest extends ResourceTest {
             return comments;
         }
 
-        @Override @SuppressWarnings("checkstyle:ParameterNumber")
-        protected void createComment(final CommentType commentType, final String relativePath, final int lineStart, final int lineEnd,
+        @Override
+        @SuppressWarnings("checkstyle:ParameterNumber")
+        protected void createComment(final CommentType commentType, final String relativePath, final int lineStart,
+                final int lineEnd,
                 final String message, final String title,
                 final int columnStart, final int columnEnd, final String details, final String markDownDetails) {
-            comments.add(String.format(Locale.ENGLISH, "[%s] %s:%d-%d: %s (%s)", commentType.name(), relativePath, lineStart, lineEnd, message, title));
+            comments.add(
+                    String.format(Locale.ENGLISH, "[%s] %s:%d-%d: %s (%s)", commentType.name(), relativePath, lineStart,
+                            lineEnd, message, title));
         }
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
@@ -52,6 +52,14 @@ class CoverageScoreTest {
     }
 
     @Test
+    void shouldFailWhenSoftwareMetricIsUsed() {
+        var report = createReport(Metric.LINE, "99/100");
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(
+                () -> new CoverageScoreBuilder().withReport(report, Metric.LOC))
+                .withMessageContaining("The metric must be a coverage metric, but is LOC");
+    }
+
+    @Test
     void shouldAssumeNoCoverageIfMissing() {
         var missingCoverage = new CoverageScoreBuilder()
                 .withConfiguration(createCoverageConfiguration(1, 1))

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -121,7 +121,11 @@ class GradingReportTest {
                 "Branch Coverage - 20 of 100", "60% (40 missed branches)",
                 "Mutation Coverage - 20 of 100: 60% (40 survived mutations)",
                 "Checkstyle - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                "SpotBugs - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                "SpotBugs - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)",
+                "Cyclomatic Complexity: 10",
+                "Cognitive Complexity: 100",
+                "N-Path Complexity: <n/a>",
+                "Non Commenting Source Statements: <n/a>");
         assertThat(results.getTextSummary(score)).isEqualTo(
                 "Autograding score - 167 of 500 (33%)");
         assertThat(results.getMarkdownDetails(score)).contains(
@@ -135,7 +139,11 @@ class GradingReportTest {
                 "Style - 30 of 100",
                 "title=\"Style: 30%\"",
                 "Bugs - 0 of 100",
-                "title=\"Bugs: 0%\"");
+                "title=\"Bugs: 0%\"",
+                "|Cyclomatic Complexity|10",
+                "|Cognitive Complexity|100",
+                "|Non Commenting Source Statements|<n/a>",
+                "|N-Path Complexity|<n/a>");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/MetricMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/MetricMarkdownTest.java
@@ -1,0 +1,180 @@
+package edu.hm.hafner.grading;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.util.FilteredLog;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests the class {@link AnalysisMarkdown}.
+ *
+ * @author Ullrich Hafner
+ */
+class MetricMarkdownTest {
+    private static final FilteredLog LOG = new FilteredLog("Test");
+
+    @Test
+    void shouldSkipWhenThereAreNoScores() {
+        var aggregation = new AggregatedScore("{}", LOG);
+
+        var writer = new MetricMarkdown();
+
+        assertThat(writer.createDetails(aggregation, true)).contains("Metrics Score: not enabled");
+        assertThat(writer.createDetails(aggregation)).isEmpty();
+        assertThat(writer.createSummary(aggregation)).isEmpty();
+    }
+
+    @Test
+    void shouldShowScoreWithOneResult() {
+        var score = new AggregatedScore("""
+                {
+                  "metrics": [{
+                    "name": "Toplevel Metrics",
+                    "tools": [
+                      {
+                        "name": "Cyclomatic Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "complexity"
+                      }
+                    ]
+                  }]
+                }
+                """, LOG);
+
+        var root = new ModuleNode("Root");
+        root.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
+        score.gradeMetrics((tool, log) -> root);
+
+        var metricMarkdown = new MetricMarkdown();
+
+        assertThat(metricMarkdown.createSummary(score)).hasSize(1).first().asString().contains(
+                "Cyclomatic Complexity: 10");
+        assertThat(metricMarkdown.createDetails(score))
+                .contains("Toplevel Metrics")
+                .contains("|Cyclomatic Complexity|10");
+    }
+
+    @Test
+    void shouldShowScoreWithTwoResults() {
+        var score = new AggregatedScore("""
+                {
+                  "metrics": [{
+                    "name": "Toplevel Metrics",
+                    "tools": [
+                      {
+                        "name": "Cyclomatic Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "complexity"
+                      },
+                      {
+                        "name": "Cognitive Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "cognitive-complexity"
+                      }
+                    ]
+                  }]
+                }
+                """, LOG);
+
+        score.gradeMetrics((tool, log) -> createNodes(tool));
+
+        var metricMarkdown = new MetricMarkdown();
+
+        assertThat(metricMarkdown.createSummary(score)).hasSize(2).satisfiesExactly(
+                first -> assertThat(first).asString().contains("Cyclomatic Complexity: 10"),
+                second -> assertThat(second).asString().contains("Cognitive Complexity: 100"));
+
+        assertThat(metricMarkdown.createDetails(score))
+                .contains("Toplevel Metrics")
+                .contains("|Cyclomatic Complexity|10");
+    }
+
+    @Test
+    void shouldShowScoreWithThreeResults() {
+        var score = new AggregatedScore("""
+                {
+                  "metrics": [{
+                    "name": "Toplevel Metrics",
+                    "tools": [
+                      {
+                        "name": "Cyclomatic Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "complexity"
+                      },
+                      {
+                        "name": "Cognitive Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "cognitive-complexity"
+                      },
+                      {
+                        "name": "LOC",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "loc"
+                      }
+                    ]
+                  }]
+                }
+                """, LOG);
+
+        score.gradeMetrics((tool, log) -> createNodes(tool));
+
+        var metricMarkdown = new MetricMarkdown();
+
+        assertThat(metricMarkdown.createSummary(score)).hasSize(3).satisfiesExactly(
+                first -> assertThat(first).asString().contains("Cyclomatic Complexity: 10"),
+                second -> assertThat(second).asString().contains("Cognitive Complexity: 100"),
+                third -> assertThat(third).asString().contains("LOC: 1000"));
+
+        assertThat(metricMarkdown.createDetails(score))
+                .contains("Toplevel Metrics")
+                .contains("|Cyclomatic Complexity|10");
+    }
+
+    static ModuleNode createNodes(final ToolConfiguration tool) {
+        var root = new ModuleNode(tool.getMetric());
+        root.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
+        root.addValue(new Value(Metric.COGNITIVE_COMPLEXITY, 100));
+        root.addValue(new Value(Metric.LOC, 1000));
+        return root;
+    }
+
+    @Test
+    void shouldHandleMissingValue() {
+        var score = new AggregatedScore("""
+                {
+                  "metrics": [{
+                    "name": "Toplevel Metrics",
+                    "tools": [
+                      {
+                        "name": "Cyclomatic Complexity",
+                        "id": "metrics",
+                        "pattern": "target/**metrics.xml",
+                        "metric": "complexity"
+                      }
+                    ]
+                  }]
+                }
+                """, LOG);
+
+        var root = new ModuleNode("Root");
+        score.gradeMetrics((tool, log) -> root);
+
+        var metricMarkdown = new MetricMarkdown();
+
+        assertThat(metricMarkdown.createSummary(score)).hasSize(1).first().asString().contains(
+                "Cyclomatic Complexity: <n/a>");
+        assertThat(metricMarkdown.createDetails(score))
+                .contains("Toplevel Metrics")
+                .contains("|Cyclomatic Complexity|<n/a>");
+    }
+}

--- a/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
@@ -24,6 +24,7 @@ class ReportFinderTest {
     void shouldFindSources() {
         var finder = new ReportFinder();
 
-        assertThat(finder.findGlob("regex:.*FileSystem.*\\.java", "src/main/java/", LOG)).hasSize(3);
+        assertThat(finder.findGlob("regex:.*FileSystem.*\\.java", "src/main/java/", LOG))
+                .hasSize(4);
     }
 }

--- a/src/test/resources/edu/hm/hafner/grading/metrics.xml
+++ b/src/test/resources/edu/hm/hafner/grading/metrics.xml
@@ -1,0 +1,1339 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metrics version="7.5.0-metrics" timestamp="2024-10-17T09:01:14.294" source="PMD">
+<package name="edu.hm.hafner.util">
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java">
+<class name="Ensure">
+<metric name="NCSS" value="149"/>
+<method name="that" beginline="47" endline="47" begincolumn="36" endcolumn="40">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="64" endline="64" begincolumn="42" endcolumn="46">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="78" endline="78" begincolumn="37" endcolumn="41">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="91" endline="91" begincolumn="39" endcolumn="43">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="105" endline="105" begincolumn="34" endcolumn="38">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="118" endline="118" begincolumn="35" endcolumn="39">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="that" beginline="131" endline="131" begincolumn="38" endcolumn="42">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="thatStatementIsNeverReached" beginline="138" endline="138" begincolumn="24" endcolumn="51">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="thatStatementIsNeverReached" beginline="153" endline="153" begincolumn="24" endcolumn="51">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="throwException" beginline="170" endline="170" begincolumn="25" endcolumn="39">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="throwNullPointerException" beginline="187" endline="187" begincolumn="25" endcolumn="50">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="Ensure" beginline="191" endline="191" begincolumn="13" endcolumn="19">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="1"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+<class name="IterableCondition">
+<metric name="NCSS" value="13"/>
+<method name="IterableCondition" beginline="205" endline="205" begincolumn="16" endcolumn="33">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="216" endline="216" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="235" endline="235" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="7"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+</class>
+<class name="CollectionCondition">
+<metric name="NCSS" value="17"/>
+<method name="CollectionCondition" beginline="261" endline="261" begincolumn="16" endcolumn="35">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getValue" beginline="266" endline="266" begincolumn="23" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="contains" beginline="279" endline="279" begincolumn="21" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="contains" beginline="299" endline="299" begincolumn="21" endcolumn="29">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="doesNotContain" beginline="316" endline="316" begincolumn="21" endcolumn="35">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="doesNotContain" beginline="336" endline="336" begincolumn="21" endcolumn="35">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+<class name="ArrayCondition">
+<metric name="NCSS" value="13"/>
+<method name="ArrayCondition" beginline="356" endline="356" begincolumn="16" endcolumn="30">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="367" endline="367" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="386" endline="386" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="7"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+</class>
+<class name="StringCondition">
+<metric name="NCSS" value="23"/>
+<method name="StringCondition" beginline="412" endline="412" begincolumn="16" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="422" endline="422" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotEmpty" beginline="440" endline="440" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isNotBlank" beginline="454" endline="454" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotBlank" beginline="472" endline="472" begincolumn="21" endcolumn="31">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isBlank" beginline="480" endline="480" begincolumn="25" endcolumn="32">
+<metric name="CognitiveComplexity" value="4"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="6"/>
+</method>
+</class>
+<class name="ObjectCondition">
+<metric name="NCSS" value="39"/>
+<method name="ObjectCondition" beginline="512" endline="512" begincolumn="16" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="ObjectCondition" beginline="525" endline="525" begincolumn="16" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotNull" beginline="536" endline="536" begincolumn="21" endcolumn="30">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNotNull" beginline="554" endline="554" begincolumn="21" endcolumn="30">
+<metric name="CognitiveComplexity" value="8"/>
+<metric name="CyclomaticComplexity" value="5"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="5"/>
+</method>
+<method name="getValue" beginline="569" endline="569" begincolumn="11" endcolumn="19">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isNull" beginline="582" endline="582" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNull" beginline="600" endline="600" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isInstanceOf" beginline="617" endline="617" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="9"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="isInstanceOf" beginline="648" endline="648" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+<class name="BooleanCondition">
+<metric name="NCSS" value="14"/>
+<method name="BooleanCondition" beginline="670" endline="670" begincolumn="16" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isFalse" beginline="688" endline="688" begincolumn="21" endcolumn="28">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isFalse" beginline="700" endline="700" begincolumn="21" endcolumn="28">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isTrue" beginline="718" endline="718" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isTrue" beginline="730" endline="730" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+<class name="ExceptionCondition">
+<metric name="NCSS" value="6"/>
+<method name="ExceptionCondition" beginline="748" endline="748" begincolumn="16" endcolumn="34">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isNeverThrown" beginline="766" endline="766" begincolumn="21" endcolumn="34">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/FilteredLog.java">
+<class name="FilteredLog">
+<metric name="NCSS" value="83"/>
+<method name="FilteredLog" beginline="42" endline="42" begincolumn="12" endcolumn="23">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="FilteredLog" beginline="52" endline="52" begincolumn="12" endcolumn="23">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="FilteredLog" beginline="64" endline="64" begincolumn="12" endcolumn="23">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="readResolve" beginline="74" endline="74" begincolumn="22" endcolumn="33">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="logInfo" beginline="86" endline="86" begincolumn="17" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="logInfo" beginline="107" endline="107" begincolumn="17" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="logError" beginline="117" endline="117" begincolumn="17" endcolumn="25">
+<metric name="CognitiveComplexity" value="4"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="9"/>
+<metric name="NPathComplexity" value="5"/>
+</method>
+<method name="logError" beginline="144" endline="144" begincolumn="17" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="logException" beginline="161" endline="161" begincolumn="17" endcolumn="29">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="size" beginline="180" endline="180" begincolumn="16" endcolumn="20">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="logSummary" beginline="191" endline="191" begincolumn="17" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="1"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getInfoMessages" beginline="200" endline="200" begincolumn="25" endcolumn="40">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getErrorMessages" beginline="215" endline="215" begincolumn="25" endcolumn="41">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="11"/>
+<metric name="NPathComplexity" value="5"/>
+</method>
+<method name="hasErrors" beginline="238" endline="238" begincolumn="20" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="merge" beginline="254" endline="254" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="equals" beginline="267" endline="267" begincolumn="20" endcolumn="26">
+<metric name="CognitiveComplexity" value="4"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="30"/>
+</method>
+<method name="hashCode" beginline="284" endline="284" begincolumn="16" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Generated.java">
+<class name="Generated">
+<metric name="NCSS" value="2"/>
+<method name="value" beginline="24" endline="24" begincolumn="14" endcolumn="19">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="1"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/LineRange.java">
+<class name="LineRange">
+<metric name="NCSS" value="41"/>
+<method name="LineRange" beginline="26" endline="26" begincolumn="12" endcolumn="21">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="LineRange" beginline="38" endline="38" begincolumn="12" endcolumn="21">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="11"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="getStart" beginline="58" endline="58" begincolumn="16" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getEnd" beginline="67" endline="67" begincolumn="16" endcolumn="22">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getLines" beginline="76" endline="76" begincolumn="34" endcolumn="42">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="contains" beginline="90" endline="90" begincolumn="20" endcolumn="28">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isSingleLine" beginline="99" endline="99" begincolumn="20" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="equals" beginline="105" endline="105" begincolumn="20" endcolumn="26">
+<metric name="CognitiveComplexity" value="4"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="12"/>
+</method>
+<method name="hashCode" beginline="119" endline="119" begincolumn="16" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="toString" beginline="124" endline="124" begincolumn="19" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/LineRangeList.java">
+<class name="LineRangeList">
+<metric name="NCSS" value="163"/>
+<method name="LineRangeList" beginline="50" endline="50" begincolumn="12" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="LineRangeList" beginline="60" endline="60" begincolumn="12" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="LineRangeList" beginline="73" endline="73" begincolumn="12" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="LineRangeList" beginline="85" endline="85" begincolumn="12" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="addAll" beginline="92" endline="92" begincolumn="26" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="addAll" beginline="113" endline="113" begincolumn="26" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="ensure" beginline="126" endline="126" begincolumn="18" endcolumn="24">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="contains" beginline="135" endline="135" begincolumn="20" endcolumn="28">
+<metric name="CognitiveComplexity" value="6"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+<method name="get" beginline="149" endline="149" begincolumn="22" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="size" beginline="154" endline="154" begincolumn="16" endcolumn="20">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="set" beginline="159" endline="159" begincolumn="22" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="add" beginline="164" endline="164" begincolumn="17" endcolumn="20">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="add" beginline="169" endline="169" begincolumn="26" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="remove" beginline="175" endline="175" begincolumn="22" endcolumn="28">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="clear" beginline="180" endline="180" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="iterator" beginline="186" endline="186" begincolumn="32" endcolumn="40">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="listIterator" beginline="192" endline="192" begincolumn="36" endcolumn="48">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="listIterator" beginline="198" endline="198" begincolumn="36" endcolumn="48">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="trim" beginline="205" endline="205" begincolumn="17" endcolumn="21">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+<class name="Cursor">
+<metric name="NCSS" value="103"/>
+<method name="Cursor" beginline="219" endline="219" begincolumn="9" endcolumn="15">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="Cursor" beginline="223" endline="223" begincolumn="9" endcolumn="15">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="prev" beginline="230" endline="230" begincolumn="22" endcolumn="26">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="5"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="6"/>
+</method>
+<method name="next" beginline="245" endline="245" begincolumn="26" endcolumn="30">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="previous" beginline="252" endline="252" begincolumn="26" endcolumn="34">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="remove" beginline="262" endline="262" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="hasNext" beginline="269" endline="269" begincolumn="24" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="hasPrevious" beginline="274" endline="274" begincolumn="24" endcolumn="35">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="read" beginline="284" endline="284" begincolumn="21" endcolumn="25">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+<method name="write" beginline="297" endline="297" begincolumn="22" endcolumn="27">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="write" beginline="307" endline="307" begincolumn="22" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="compare" beginline="320" endline="320" begincolumn="24" endcolumn="31">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="skip" beginline="335" endline="335" begincolumn="24" endcolumn="28">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="count" beginline="349" endline="349" begincolumn="21" endcolumn="26">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="nextIndex" beginline="360" endline="360" begincolumn="20" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="previousIndex" beginline="365" endline="365" begincolumn="20" endcolumn="33">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="copy" beginline="369" endline="369" begincolumn="23" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="adjust" beginline="373" endline="373" begincolumn="22" endcolumn="28">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="rewrite" beginline="392" endline="392" begincolumn="26" endcolumn="33">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="set" beginline="403" endline="403" begincolumn="21" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="add" beginline="411" endline="411" begincolumn="21" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="delete" beginline="422" endline="422" begincolumn="26" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="sizeOf" beginline="429" endline="429" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="sizeOf" beginline="441" endline="441" begincolumn="21" endcolumn="27">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/LookaheadStream.java">
+<class name="LookaheadStream">
+<metric name="NCSS" value="42"/>
+<method name="LookaheadStream" beginline="31" endline="31" begincolumn="12" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="LookaheadStream" beginline="43" endline="43" begincolumn="12" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getFileName" beginline="49" endline="49" begincolumn="19" endcolumn="30">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="close" beginline="54" endline="54" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="hasNext" beginline="64" endline="64" begincolumn="20" endcolumn="27">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="hasNext" beginline="76" endline="76" begincolumn="20" endcolumn="27">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="peekNext" beginline="95" endline="95" begincolumn="19" endcolumn="27">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="fillLookahead" beginline="102" endline="102" begincolumn="18" endcolumn="31">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="next" beginline="114" endline="114" begincolumn="19" endcolumn="23">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getLine" beginline="129" endline="129" begincolumn="16" endcolumn="23">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="toString" beginline="134" endline="134" begincolumn="19" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/PathUtil.java">
+<class name="PathUtil">
+<metric name="NCSS" value="65"/>
+<method name="exists" beginline="42" endline="42" begincolumn="20" endcolumn="26">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="exists" beginline="68" endline="68" begincolumn="20" endcolumn="26">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getAbsolutePath" beginline="83" endline="83" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getAbsolutePath" beginline="103" endline="103" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getRelativePath" beginline="126" endline="126" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getRelativePath" beginline="149" endline="149" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getRelativePath" beginline="172" endline="172" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="getRelativePath" beginline="197" endline="197" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getRelativePath" beginline="212" endline="212" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createAbsolutePath" beginline="232" endline="232" begincolumn="19" endcolumn="37">
+<metric name="CognitiveComplexity" value="6"/>
+<metric name="CyclomaticComplexity" value="6"/>
+<metric name="NCSS" value="13"/>
+<metric name="NPathComplexity" value="18"/>
+</method>
+<method name="isAbsolute" beginline="263" endline="263" begincolumn="20" endcolumn="30">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="normalize" beginline="276" endline="276" begincolumn="18" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="makeUnixPath" beginline="280" endline="280" begincolumn="20" endcolumn="32">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/PrefixLogger.java">
+<class name="PrefixLogger">
+<metric name="NCSS" value="15"/>
+<method name="PrefixLogger" beginline="25" endline="25" begincolumn="12" endcolumn="24">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="log" beginline="46" endline="46" begincolumn="17" endcolumn="20">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="logEachLine" beginline="56" endline="56" begincolumn="17" endcolumn="28">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="print" beginline="60" endline="60" begincolumn="18" endcolumn="23">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/ResourceExtractor.java">
+<class name="ResourceExtractor">
+<metric name="NCSS" value="81"/>
+<method name="ResourceExtractor" beginline="37" endline="37" begincolumn="12" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="ResourceExtractor" beginline="42" endline="42" begincolumn="5" endcolumn="22">
+<metric name="CognitiveComplexity" value="5"/>
+<metric name="CyclomaticComplexity" value="8"/>
+<metric name="NCSS" value="17"/>
+<metric name="NPathComplexity" value="16"/>
+</method>
+<method name="getResourcePath" beginline="66" endline="66" begincolumn="19" endcolumn="34">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="isReadingFromJarFile" beginline="70" endline="70" begincolumn="20" endcolumn="40">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="extract" beginline="84" endline="84" begincolumn="17" endcolumn="24">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+<class name="Extractor">
+<metric name="NCSS" value="7"/>
+<method name="Extractor" beginline="100" endline="100" begincolumn="9" endcolumn="18">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getEntryPoint" beginline="104" endline="104" begincolumn="14" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="extractFiles" beginline="108" endline="108" begincolumn="23" endcolumn="35">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="1"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+<class name="FolderExtractor">
+<metric name="NCSS" value="14"/>
+<method name="FolderExtractor" beginline="115" endline="115" begincolumn="9" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="extractFiles" beginline="120" endline="120" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="copy" beginline="133" endline="133" begincolumn="22" endcolumn="26">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+</class>
+<class name="JarExtractor">
+<metric name="NCSS" value="27"/>
+<method name="JarExtractor" beginline="147" endline="147" begincolumn="9" endcolumn="21">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="extractFiles" beginline="152" endline="152" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="5"/>
+<metric name="CyclomaticComplexity" value="7"/>
+<metric name="NCSS" value="14"/>
+<metric name="NPathComplexity" value="10"/>
+</method>
+<method name="copy" beginline="173" endline="173" begincolumn="22" endcolumn="26">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="10"/>
+<metric name="NPathComplexity" value="8"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/SecureXmlParserFactory.java">
+<class name="SecureXmlParserFactory">
+<metric name="NCSS" value="110"/>
+<method name="createDocumentBuilder" beginline="85" endline="85" begincolumn="28" endcolumn="49">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="10"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createDocumentBuilderFactory" beginline="102" endline="102" begincolumn="28" endcolumn="56">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="setFeatures" beginline="106" endline="106" begincolumn="18" endcolumn="29">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+<method name="setFeature" beginline="115" endline="115" begincolumn="18" endcolumn="28">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="clearAttributes" beginline="124" endline="124" begincolumn="18" endcolumn="33">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="clearAttributes" beginline="135" endline="135" begincolumn="18" endcolumn="33">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="createSaxParser" beginline="151" endline="151" begincolumn="22" endcolumn="37">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createSaxParserFactory" beginline="166" endline="166" begincolumn="22" endcolumn="44">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="secureParser" beginline="176" endline="176" begincolumn="18" endcolumn="30">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="configureSaxParserFactory" beginline="193" endline="193" begincolumn="17" endcolumn="42">
+<metric name="CognitiveComplexity" value="6"/>
+<metric name="CyclomaticComplexity" value="5"/>
+<metric name="NCSS" value="9"/>
+<metric name="NPathComplexity" value="9"/>
+</method>
+<method name="createXmlStreamReader" beginline="224" endline="224" begincolumn="28" endcolumn="49">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createXmlEventReader" beginline="242" endline="242" begincolumn="27" endcolumn="47">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createSecureInputFactory" beginline="251" endline="251" begincolumn="29" endcolumn="53">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="createXmlInputFactory" beginline="259" endline="259" begincolumn="21" endcolumn="42">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="parse" beginline="278" endline="278" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="readDocument" beginline="300" endline="300" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createInputSource" beginline="309" endline="309" begincolumn="25" endcolumn="42">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="createTransformer" beginline="321" endline="321" begincolumn="24" endcolumn="41">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="createTransformerFactory" beginline="336" endline="336" begincolumn="24" endcolumn="48">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+<class name="ParsingException">
+<metric name="NCSS" value="10"/>
+<method name="ParsingException" beginline="352" endline="352" begincolumn="16" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="ParsingException" beginline="370" endline="370" begincolumn="16" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="ParsingException" beginline="390" endline="390" begincolumn="16" endcolumn="32">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="createMessage" beginline="394" endline="394" begincolumn="31" endcolumn="44">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/TreeString.java">
+<class name="TreeString">
+<metric name="NCSS" value="57"/>
+<method name="TreeString" beginline="33" endline="33" begincolumn="5" endcolumn="15">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="TreeString" beginline="46" endline="46" begincolumn="5" endcolumn="15">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getLabel" beginline="54" endline="54" begincolumn="12" endcolumn="20">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="split" beginline="70" endline="70" begincolumn="16" endcolumn="21">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="8"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getParent" beginline="85" endline="85" begincolumn="16" endcolumn="25">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="depth" beginline="95" endline="95" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="5"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="equals" beginline="104" endline="104" begincolumn="20" endcolumn="26">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="4"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="6"/>
+</method>
+<method name="hashCode" beginline="115" endline="115" begincolumn="16" endcolumn="24">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="toString" beginline="123" endline="123" begincolumn="19" endcolumn="27">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="11"/>
+<metric name="NPathComplexity" value="4"/>
+</method>
+<method name="dedup" beginline="146" endline="146" begincolumn="10" endcolumn="15">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="7"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="isBlank" beginline="157" endline="157" begincolumn="20" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="valueOf" beginline="170" endline="170" begincolumn="30" endcolumn="37">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/TreeStringBuilder.java">
+<class name="TreeStringBuilder">
+<metric name="NCSS" value="58"/>
+<method name="intern" beginline="32" endline="32" begincolumn="23" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="intern" beginline="44" endline="44" begincolumn="23" endcolumn="29">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="dedup" beginline="51" endline="51" begincolumn="17" endcolumn="22">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="getRoot" beginline="58" endline="58" begincolumn="11" endcolumn="18">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+<class name="Child">
+<metric name="NCSS" value="47"/>
+<method name="Child" beginline="70" endline="70" begincolumn="9" endcolumn="14">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="intern" beginline="82" endline="82" begincolumn="22" endcolumn="28">
+<metric name="CognitiveComplexity" value="11"/>
+<metric name="CyclomaticComplexity" value="6"/>
+<metric name="NCSS" value="21"/>
+<metric name="NPathComplexity" value="16"/>
+</method>
+<method name="makeWritable" beginline="121" endline="121" begincolumn="22" endcolumn="34">
+<metric name="CognitiveComplexity" value="1"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="3"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="split" beginline="136" endline="136" begincolumn="23" endcolumn="28">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+<method name="commonPrefix" beginline="156" endline="156" begincolumn="21" endcolumn="33">
+<metric name="CognitiveComplexity" value="3"/>
+<metric name="CyclomaticComplexity" value="3"/>
+<metric name="NCSS" value="6"/>
+<metric name="NPathComplexity" value="3"/>
+</method>
+<method name="dedup" beginline="173" endline="173" begincolumn="22" endcolumn="27">
+<metric name="CognitiveComplexity" value="2"/>
+<metric name="CyclomaticComplexity" value="2"/>
+<metric name="NCSS" value="4"/>
+<metric name="NPathComplexity" value="2"/>
+</method>
+<method name="getNode" beginline="180" endline="180" begincolumn="20" endcolumn="27">
+<metric name="CognitiveComplexity" value="0"/>
+<metric name="CyclomaticComplexity" value="1"/>
+<metric name="NCSS" value="2"/>
+<metric name="NPathComplexity" value="1"/>
+</method>
+</class>
+</file>
+<file name="/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/VisibleForTesting.java">
+<class name="VisibleForTesting">
+<metric name="NCSS" value="1"/>
+</class>
+</file>
+</package>
+</metrics>


### PR DESCRIPTION
The latest release of the coverage-model supports reporting of software metrics. While it does not yet make sense to use them in autograding, it would be helpful to show the results of the recorded metrics in the quality monitor.

![Bildschirmfoto 2024-10-26 um 14 25 21](https://github.com/user-attachments/assets/b9109000-40a6-4495-8c52-c17045f93b27)
