### PR TITLE
If there are failed tests then show 99% success only

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -1,18 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.io.Serial;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.Issue;
@@ -26,6 +13,19 @@ import edu.hm.hafner.grading.MetricScore.MetricScoreBuilder;
 import edu.hm.hafner.grading.TestScore.TestScoreBuilder;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.Generated;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Stores the scores of an autograding run. Persists the configuration and the scores for each metric.
@@ -390,7 +390,7 @@ public final class AggregatedScore implements Serializable {
             }
 
             builder.setConfiguration(configuration);
-            builder.setName(StringUtils.defaultIfBlank(configuration.getName(), "Tests"));
+            builder.setName(configuration.getName());
             builder.setIcon(configuration.getIcon());
 
             var aggregation = builder.aggregate(scores);

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -1,9 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.ArrayList;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.FileReaderFactory;
@@ -17,6 +13,10 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 
 /**
  * Reads analysis or coverage reports of a specific type from the file system into a corresponding Java model.
@@ -48,7 +48,8 @@ public final class FileSystemToolParser implements ToolParser {
 
     @Override
     public Node readNode(final ToolConfiguration tool, final FilteredLog log) {
-        var parser = new edu.hm.hafner.coverage.registry.ParserRegistry().get(StringUtils.upperCase(tool.getId()), ProcessingMode.IGNORE_ERRORS);
+        var parser = new edu.hm.hafner.coverage.registry.ParserRegistry().get(StringUtils.upperCase(tool.getId()),
+                ProcessingMode.IGNORE_ERRORS);
 
         var nodes = new ArrayList<Node>();
         for (Path file : REPORT_FINDER.find(log, tool.getName(), tool.getPattern())) {
@@ -80,7 +81,7 @@ public final class FileSystemToolParser implements ToolParser {
     }
 
     private ContainerNode createEmptyContainer(final ToolConfiguration tool) {
-        return new ContainerNode(tool.getName());
+        return new ContainerNode(StringUtils.defaultIfBlank(tool.getName(), getMetric(tool).getLabel()));
     }
 
     String extractMetric(final ToolConfiguration tool, final Node node) {

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -1,13 +1,13 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.function.Function;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.coverage.TestCase;
 import edu.hm.hafner.grading.TruncatedString.TruncatedStringBuilder;
+
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.function.Function;
 
 /**
  * Renders the test results in Markdown.
@@ -149,8 +149,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
             return "No test results available";
         }
         var summary = new StringBuilder(1024);
-        summary.append(format("%2d%% successful",
-                Math.round(score.getPassedSize() * 100.0 / score.getTotalSize())));
+        summary.append(format("%2d%% successful", score.getSuccessRate()));
         var joiner = new StringJoiner(", ", " (", ")");
         if (score.hasFailures()) {
             joiner.add(format(":x: %d failed", score.getFailedSize()));

--- a/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
@@ -3,8 +3,7 @@ package edu.hm.hafner.grading;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.util.FilteredLog;
-
-import java.nio.file.Path;
+import edu.hm.hafner.util.PathUtil;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,9 +24,9 @@ class ReportFinderTest {
     @Test
     void shouldFindSources() {
         var finder = new ReportFinder();
-
+        var pathUtil = new PathUtil();
         assertThat(finder.findGlob("regex:.*Markdown.*\\.java", "src/main/java/", LOG))
-                .map(Path::toString)
+                .map(pathUtil::getRelativePath)
                 .containsExactlyInAnyOrder("src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java",
                         "src/main/java/edu/hm/hafner/grading/CodeCoverageMarkdown.java",
                         "src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java",


### PR DESCRIPTION
Even if the rounded value is 100%, we should only report a 99% success rate when a test is failing.

Fixes #407 