### PR TITLE
Fix default names of scores

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -383,6 +383,7 @@ public final class AggregatedScore implements Serializable {
             for (var tool : configuration.getTools()) {
                 builder.setConfiguration(configuration);
                 builder.read(factory, tool, log);
+                builder.setName(tool.getName());
 
                 var score = builder.build();
                 scores.add(score);

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -165,7 +165,7 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
     static class AnalysisScoreBuilder extends ScoreBuilder<AnalysisScore, AnalysisConfiguration> {
         @Override
         public AnalysisScore aggregate(final List<AnalysisScore> scores) {
-            return new AnalysisScore(getName(), getIcon(), getConfiguration(), scores);
+            return new AnalysisScore(getTopLevelName(), getIcon(), getConfiguration(), scores);
         }
 
         @Override
@@ -181,6 +181,16 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
         @Override
         public String getType() {
             return "static analysis";
+        }
+
+        @Override
+        String getDefaultName() {
+            return getReport().getName();
+        }
+
+        @Override
+        String getDefaultTopLevelName() {
+            return "Static Analysis Results";
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -1,10 +1,10 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.function.Predicate;
-
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.grading.TruncatedString.TruncatedStringBuilder;
+
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Renders the coverage results in Markdown.
@@ -84,9 +84,9 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
 
     private String getImageForScoreOrCoverage(final CoverageScore score) {
         if (score.hasMaxScore()) { // show the score percentage
-            return getPercentageImage(score.getDisplayName(), score.getPercentage());
+            return getPercentageImage(score.getName(), score.getPercentage());
         }
-        return getPercentageImage(score.getDisplayName(), score.getCoveredPercentage());
+        return getPercentageImage(score.getName(), score.getCoveredPercentage());
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -172,7 +172,7 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
     static class CoverageScoreBuilder extends ScoreBuilder<CoverageScore, CoverageConfiguration> {
         @Override
         public CoverageScore aggregate(final List<CoverageScore> scores) {
-            return new CoverageScore(getName(), getIcon(), getConfiguration(), scores);
+            return new CoverageScore(getTopLevelName(), getIcon(), getConfiguration(), scores);
         }
 
         @Override
@@ -188,6 +188,11 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         @Override
         public String getType() {
             return "coverage";
+        }
+
+        @Override
+        String getDefaultTopLevelName() {
+            return "Coverage Results";
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -52,7 +52,7 @@ public final class FileSystemToolParser implements ToolParser {
                 ProcessingMode.IGNORE_ERRORS);
 
         var nodes = new ArrayList<Node>();
-        for (Path file : REPORT_FINDER.find(log, tool.getName(), tool.getPattern())) {
+        for (Path file : REPORT_FINDER.find(log, getDisplayName(tool), tool.getPattern())) {
             var factory = new FileReaderFactory(file);
             try (var reader = factory.create()) {
                 var node = parser.parse(reader, file.toString(), log);
@@ -69,10 +69,7 @@ public final class FileSystemToolParser implements ToolParser {
         }
         else {
             var aggregation = Node.merge(nodes);
-            log.logInfo("-> %s Total: %s", tool.getName(), extractMetric(tool, aggregation));
-            if (tool.getName().isBlank()) {
-                return aggregation;
-            }
+            log.logInfo("-> %s Total: %s", getDisplayName(tool), extractMetric(tool, aggregation));
             // Wrap the node into a container with the specified tool name
             var containerNode = createEmptyContainer(tool);
             containerNode.addChild(aggregation);
@@ -81,7 +78,11 @@ public final class FileSystemToolParser implements ToolParser {
     }
 
     private ContainerNode createEmptyContainer(final ToolConfiguration tool) {
-        return new ContainerNode(StringUtils.defaultIfBlank(tool.getName(), getMetric(tool).getLabel()));
+        return new ContainerNode(getDisplayName(tool));
+    }
+
+    private String getDisplayName(final ToolConfiguration tool) {
+        return StringUtils.defaultIfBlank(tool.getName(), getMetric(tool).getDisplayName());
     }
 
     String extractMetric(final ToolConfiguration tool, final Node node) {

--- a/src/main/java/edu/hm/hafner/grading/MetricScore.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricScore.java
@@ -130,7 +130,7 @@ public final class MetricScore extends Score<MetricScore, MetricConfiguration> {
     static class MetricScoreBuilder extends ScoreBuilder<MetricScore, MetricConfiguration> {
         @Override
         public MetricScore aggregate(final List<MetricScore> scores) {
-            return new MetricScore(getName(), getIcon(), getConfiguration(), scores);
+            return new MetricScore(getTopLevelName(), getIcon(), getConfiguration(), scores);
         }
 
         @Override
@@ -146,6 +146,11 @@ public final class MetricScore extends Score<MetricScore, MetricConfiguration> {
         @Override
         public String getType() {
             return "metric";
+        }
+
+        @Override
+        String getDefaultTopLevelName() {
+            return "Metrics Results";
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/Score.java
+++ b/src/main/java/edu/hm/hafner/grading/Score.java
@@ -1,16 +1,16 @@
 package edu.hm.hafner.grading;
 
+import com.google.errorprone.annotations.FormatMethod;
+
+import edu.hm.hafner.util.Ensure;
+import edu.hm.hafner.util.Generated;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
-import com.google.errorprone.annotations.FormatMethod;
-
-import edu.hm.hafner.util.Ensure;
-import edu.hm.hafner.util.Generated;
 
 /**
  * A score that has been obtained from a specific tool.
@@ -53,10 +53,6 @@ public abstract class Score<S extends Score<S, C>, C extends Configuration> impl
 
     public final String getIcon() {
         return icon;
-    }
-
-    public final String getDisplayName() {
-        return Objects.toString(getName(), configuration.getName());
     }
 
     public final C getConfiguration() {

--- a/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -13,6 +10,9 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * A builder for {@link Score} instances.
@@ -49,8 +49,18 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
         return this;
     }
 
+    String getTopLevelName() {
+        return StringUtils.defaultIfBlank(name, getDefaultTopLevelName());
+    }
+
+    abstract String getDefaultTopLevelName();
+
     String getName() {
-        return StringUtils.defaultIfBlank(name, getConfiguration().getName());
+        return StringUtils.defaultIfBlank(name, getDefaultName());
+    }
+
+    String getDefaultName() {
+        return getMetric().getDisplayName();
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -95,7 +95,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
 
     String getPercentageImage(final Score<?, ?> score) {
         if (score.hasMaxScore()) {
-            return getPercentageImage(score.getDisplayName(), score.getPercentage());
+            return getPercentageImage(score.getName(), score.getPercentage());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -248,7 +248,7 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
     static class TestScoreBuilder extends ScoreBuilder<TestScore, TestConfiguration> {
         @Override
         public TestScore aggregate(final List<TestScore> scores) {
-            return new TestScore(getName(), getIcon(), getConfiguration(), scores);
+            return new TestScore(getTopLevelName(), getIcon(), getConfiguration(), scores);
         }
 
         @Override
@@ -264,6 +264,11 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
         @Override
         public String getType() {
             return "test";
+        }
+
+        @Override
+        String getDefaultTopLevelName() {
+            return "Test Results";
         }
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisScoreTest.java
@@ -1,7 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.IssueBuilder;
@@ -9,6 +7,8 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.registry.ParserRegistry;
 import edu.hm.hafner.grading.AnalysisScore.AnalysisScoreBuilder;
+
+import java.util.List;
 
 import static edu.hm.hafner.grading.assertions.Assertions.*;
 
@@ -121,8 +121,7 @@ class AnalysisScoreTest {
                 .create(new Report());
         assertThat(score)
                 .hasImpact(0)
-                .hasValue(0)
-                .hasName("Checkstyle and SpotBugs");
+                .hasValue(0);
     }
 
     @Test
@@ -152,8 +151,7 @@ class AnalysisScoreTest {
                 .create(new Report());
         assertThat(score)
                 .hasImpact(0)
-                .hasValue(50)
-                .hasName("Checkstyle and SpotBugs");
+                .hasValue(50);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -1,17 +1,17 @@
 package edu.hm.hafner.grading;
 
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.ResourceTest;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
-import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
-
-import edu.hm.hafner.util.FilteredLog;
-import edu.hm.hafner.util.ResourceTest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -44,12 +44,10 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "tools": [
                           {
                             "id": "checkstyle",
-                            "name": "CheckStyle",
                             "pattern": "**/src/**/checkstyle*.xml"
                           },
                           {
                             "id": "pmd",
-                            "name": "PMD",
                             "pattern": "**/src/**/pmd*.xml"
                           }
                         ],
@@ -65,7 +63,6 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "tools": [
                           {
                             "id": "spotbugs",
-                            "name": "SpotBugs",
                             "pattern": "**/src/**/spotbugs*.xml"
                           }
                         ],
@@ -81,13 +78,11 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "tools": [
                           {
                             "id": "jacoco",
-                            "name": "Line Coverage",
                             "metric": "line",
                             "pattern": "**/src/**/jacoco.xml"
                           },
                           {
                             "id": "jacoco",
-                            "name": "Branch Coverage",
                             "metric": "branch",
                             "pattern": "**/src/**/jacoco.xml"
                           }
@@ -101,7 +96,6 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "tools": [
                           {
                             "id": "pit",
-                            "name": "Mutation Coverage",
                             "metric": "mutation",
                             "pattern": "**/src/**/mutations.xml"
                           }
@@ -117,25 +111,21 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "name": "Toplevel Metrics",
                         "tools": [
                           {
-                            "name": "Cyclomatic Complexity",
                             "id": "metrics",
                             "pattern": "**/src/**/metrics.xml",
                             "metric": "CyclomaticComplexity"
                           },
                           {
-                            "name": "Cognitive Complexity",
                             "id": "metrics",
                             "pattern": "**/src/**/metrics.xml",
                             "metric": "CognitiveComplexity"
                           },
                           {
-                            "name": "Non Commenting Source Statements",
                             "id": "metrics",
                             "pattern": "**/src/**/metrics.xml",
                             "metric": "NCSS"
                           },
                           {
-                            "name": "N-Path Complexity",
                             "id": "metrics",
                             "pattern": "**/src/**/metrics.xml",
                             "metric": "NPathComplexity"
@@ -152,7 +142,6 @@ public class AutoGradingRunnerITest extends ResourceTest {
                 "tools": [
                   {
                     "id": "junit",
-                    "name": "Unittests",
                     "pattern": "**/does-not-exist/TEST*.xml"
                   }
                 ],
@@ -169,12 +158,10 @@ public class AutoGradingRunnerITest extends ResourceTest {
                   "tools": [
                     {
                       "id": "checkstyle",
-                      "name": "CheckStyle",
                       "pattern": "**/does-not-exist/checkstyle*.xml"
                     },
                     {
                       "id": "pmd",
-                      "name": "PMD",
                       "pattern": "**/does-not-exist/pmd*.xml"
                     }
                   ],
@@ -190,7 +177,6 @@ public class AutoGradingRunnerITest extends ResourceTest {
                   "tools": [
                     {
                       "id": "spotbugs",
-                      "name": "SpotBugs",
                       "pattern": "**/does-not-exist/spotbugs*.xml"
                     }
                   ],
@@ -206,13 +192,11 @@ public class AutoGradingRunnerITest extends ResourceTest {
                   "tools": [
                       {
                         "id": "jacoco",
-                        "name": "Line Coverage",
                         "metric": "line",
                         "pattern": "**/does-not-exist/jacoco.xml"
                       },
                       {
                         "id": "jacoco",
-                        "name": "Branch Coverage",
                         "metric": "branch",
                         "pattern": "**/does-not-exist/jacoco.xml"
                       }
@@ -226,7 +210,184 @@ public class AutoGradingRunnerITest extends ResourceTest {
                   "tools": [
                       {
                         "id": "pit",
-                        "name": "Mutation Coverage",
+                        "metric": "mutation",
+                        "pattern": "**/does-not-exist/mutations.xml"
+                      }
+                    ],
+                "name": "PIT",
+                "maxScore": 100,
+                "coveredPercentageImpact": 1,
+                "missedPercentageImpact": -1
+              }
+              ]
+            }
+            """;
+    private static final String CONFIGURATION_WRONG_PATHS_CUSTOM_TOP_LEVEL_NAMES = """
+            {
+              "tests": {
+                "tools": [
+                  {
+                    "id": "junit",
+                    "pattern": "**/does-not-exist/TEST*.xml"
+                  }
+                ],
+                "passedImpact": 10,
+                "skippedImpact": -1,
+                "failureImpact": -5,
+                "maxScore": 100
+              },
+              "analysis": [
+                {
+                  "name": "Style",
+                  "id": "style",
+                  "tools": [
+                    {
+                      "id": "checkstyle",
+                      "pattern": "**/does-not-exist/checkstyle*.xml"
+                    },
+                    {
+                      "id": "pmd",
+                      "pattern": "**/does-not-exist/pmd*.xml"
+                    }
+                  ],
+                  "errorImpact": 1,
+                  "highImpact": 2,
+                  "normalImpact": 3,
+                  "lowImpact": 4,
+                  "maxScore": 100
+                },
+                {
+                  "name": "Bugs",
+                  "id": "bugs",
+                  "tools": [
+                    {
+                      "id": "spotbugs",
+                      "pattern": "**/does-not-exist/spotbugs*.xml"
+                    }
+                  ],
+                  "errorImpact": -11,
+                  "highImpact": -12,
+                  "normalImpact": -13,
+                  "lowImpact": -14,
+                  "maxScore": 100
+                }
+              ],
+              "coverage": [
+              {
+                  "tools": [
+                      {
+                        "id": "jacoco",
+                        "metric": "line",
+                        "pattern": "**/does-not-exist/jacoco.xml"
+                      },
+                      {
+                        "id": "jacoco",
+                        "metric": "branch",
+                        "pattern": "**/does-not-exist/jacoco.xml"
+                      }
+                    ],
+                "name": "JaCoCo",
+                "maxScore": 100,
+                "coveredPercentageImpact": 1,
+                "missedPercentageImpact": -1
+              },
+              {
+                  "tools": [
+                      {
+                        "id": "pit",
+                        "metric": "mutation",
+                        "pattern": "**/does-not-exist/mutations.xml"
+                      }
+                    ],
+                "name": "PIT",
+                "maxScore": 100,
+                "coveredPercentageImpact": 1,
+                "missedPercentageImpact": -1
+              }
+              ]
+            }
+            """;
+    private static final String CONFIGURATION_WRONG_PATHS_CUSTOM_NAMES = """
+            {
+              "tests": {
+                "tools": [
+                  {
+                    "id": "junit",
+                    "name": "tests",
+                    "pattern": "**/does-not-exist/TEST*.xml"
+                  }
+                ],
+                "name": "JUnit",
+                "passedImpact": 10,
+                "skippedImpact": -1,
+                "failureImpact": -5,
+                "maxScore": 100
+              },
+              "analysis": [
+                {
+                  "name": "Style",
+                  "id": "style",
+                  "tools": [
+                    {
+                      "id": "checkstyle",
+                      "name": "checkstyle",
+                      "pattern": "**/does-not-exist/checkstyle*.xml"
+                    },
+                    {
+                      "id": "pmd",
+                      "name": "pmd",
+                      "pattern": "**/does-not-exist/pmd*.xml"
+                    }
+                  ],
+                  "errorImpact": 1,
+                  "highImpact": 2,
+                  "normalImpact": 3,
+                  "lowImpact": 4,
+                  "maxScore": 100
+                },
+                {
+                  "name": "Bugs",
+                  "id": "bugs",
+                  "tools": [
+                    {
+                      "id": "spotbugs",
+                      "name": "spotbugs",
+                      "pattern": "**/does-not-exist/spotbugs*.xml"
+                    }
+                  ],
+                  "errorImpact": -11,
+                  "highImpact": -12,
+                  "normalImpact": -13,
+                  "lowImpact": -14,
+                  "maxScore": 100
+                }
+              ],
+              "coverage": [
+              {
+                  "tools": [
+                      {
+                        "id": "jacoco",
+                        "name": "line",
+                        "metric": "line",
+                        "pattern": "**/does-not-exist/jacoco.xml"
+                      },
+                      {
+                        "id": "jacoco",
+                        "name": "branch",
+                        "metric": "branch",
+                        "pattern": "**/does-not-exist/jacoco.xml"
+                      }
+                    ],
+                "name": "JaCoCo",
+                "maxScore": 100,
+                "coveredPercentageImpact": 1,
+                "missedPercentageImpact": -1
+              },
+              {
+                  "tools": [
+                      {
+                        "id": "pit",
+                        "name": "pit",
                         "metric": "mutation",
                         "pattern": "**/does-not-exist/mutations.xml"
                       }
@@ -317,7 +478,7 @@ public class AutoGradingRunnerITest extends ResourceTest {
         assertThat(runAutoGrading())
                 .contains(new String[]{
                         "Processing 1 test configuration(s)",
-                        "Configuration error for 'Unittests'?",
+                        "Configuration error for 'Number of Tests'?",
                         "JUnit Score: 100 of 100",
                         "Processing 2 coverage configuration(s)",
                         "=> JaCoCo Score: 0 of 100",
@@ -333,6 +494,58 @@ public class AutoGradingRunnerITest extends ResourceTest {
                         "-> PMD (pmd): No warnings",
                         "=> Style Score: 0 of 100",
                         "-> SpotBugs (spotbugs): No warnings",
+                        "=> Bugs Score: 100 of 100",
+                        "Autograding score - 200 of 500"});
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "CONFIG", value = CONFIGURATION_WRONG_PATHS_CUSTOM_TOP_LEVEL_NAMES)
+    void shouldShowErrorsWithCustomTopLevelNames() {
+        assertThat(runAutoGrading())
+                .contains(new String[]{
+                        "Processing 1 test configuration(s)",
+                        "Configuration error for 'Number of Tests'?",
+                        "Tests Score: 100 of 100",
+                        "Processing 2 coverage configuration(s)",
+                        "=> JaCoCo Score: 0 of 100",
+                        "Configuration error for 'Line Coverage'?",
+                        "Configuration error for 'Branch Coverage'?",
+                        "=> PIT Score: 0 of 100",
+                        "Configuration error for 'Mutation Coverage'?",
+                        "Processing 2 static analysis configuration(s)",
+                        "Configuration error for 'CheckStyle'?",
+                        "Configuration error for 'PMD'?",
+                        "Configuration error for 'SpotBugs'?",
+                        "-> CheckStyle (checkstyle): No warnings",
+                        "-> PMD (pmd): No warnings",
+                        "=> Style Score: 0 of 100",
+                        "-> SpotBugs (spotbugs): No warnings",
+                        "=> Bugs Score: 100 of 100",
+                        "Autograding score - 200 of 500"});
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "CONFIG", value = CONFIGURATION_WRONG_PATHS_CUSTOM_NAMES)
+    void shouldShowErrorsWithCustomNames() {
+        assertThat(runAutoGrading())
+                .contains(new String[]{
+                        "Processing 1 test configuration(s)",
+                        "Configuration error for 'tests'?",
+                        "JUnit Score: 100 of 100",
+                        "Processing 2 coverage configuration(s)",
+                        "=> JaCoCo Score: 0 of 100",
+                        "Configuration error for 'line'?",
+                        "Configuration error for 'branch'?",
+                        "=> PIT Score: 0 of 100",
+                        "Configuration error for 'pit'?",
+                        "Processing 2 static analysis configuration(s)",
+                        "Configuration error for 'checkstyle'?",
+                        "Configuration error for 'pmd'?",
+                        "Configuration error for 'spotbugs'?",
+                        "-> checkstyle (checkstyle): No warnings",
+                        "-> pmd (pmd): No warnings",
+                        "=> Style Score: 0 of 100",
+                        "-> spotbugs (spotbugs): No warnings",
                         "=> Bugs Score: 100 of 100",
                         "Autograding score - 200 of 500"});
     }

--- a/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.Locale;
-
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.coverage.Coverage;
@@ -10,6 +7,9 @@ import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.grading.CoverageScore.CoverageScoreBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.List;
+import java.util.Locale;
 
 import static edu.hm.hafner.grading.assertions.Assertions.*;
 
@@ -110,11 +110,11 @@ class CoverageScoreTest {
         var first = new CoverageScoreBuilder()
                 .setConfiguration(createCoverageConfiguration(0, 1))
                 .create(createReport(Metric.LINE, "5/100"), Metric.LINE);
-        assertThat(first).hasImpact(5).hasValue(5).hasName("Code Coverage");
+        assertThat(first).hasImpact(5).hasValue(5).hasName("Line Coverage");
         var second = new CoverageScoreBuilder()
                 .setConfiguration(createCoverageConfiguration(0, 1))
                 .create(createReport(Metric.BRANCH, "15/100"), Metric.BRANCH);
-        assertThat(second).hasImpact(15).hasValue(15).hasName("Code Coverage");
+        assertThat(second).hasImpact(15).hasValue(15).hasName("Branch Coverage");
 
         var aggregation = new CoverageScoreBuilder()
                 .setName("Aggregation")

--- a/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.Locale;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +9,9 @@ import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.TestCase.TestCaseBuilder;
 import edu.hm.hafner.coverage.TestCase.TestResult;
 import edu.hm.hafner.grading.TestScore.TestScoreBuilder;
+
+import java.util.List;
+import java.util.Locale;
 
 import static edu.hm.hafner.grading.assertions.Assertions.*;
 
@@ -259,8 +259,7 @@ class TestScoreTest {
                 .create(createTestReport(0, 0, 0), Metric.TESTS);
         assertThat(score)
                 .hasImpact(0)
-                .hasValue(0)
-                .hasName("JUnit Test Results");
+                .hasValue(0);
     }
 
     @Test
@@ -289,8 +288,7 @@ class TestScoreTest {
                 .create(createTestReport(0, 0, 0), Metric.TESTS);
         assertThat(score)
                 .hasImpact(0)
-                .hasValue(50)
-                .hasName("JUnit Test Results");
+                .hasValue(50);
     }
 
     @Test


### PR DESCRIPTION
It makes sense to define a default name for each of the scores. If no name is given, this default name will be picked.