### PR TITLE
Fix test score computation for negative impact

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/TestConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/TestConfiguration.java
@@ -1,13 +1,13 @@
 package edu.hm.hafner.grading;
 
-import java.io.Serial;
-import java.util.List;
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import edu.hm.hafner.util.Ensure;
 import edu.hm.hafner.util.Generated;
+
+import java.io.Serial;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Configuration to grade test results. The configuration specifies the impact of the test results on the score. This
@@ -77,6 +77,9 @@ public final class TestConfiguration extends Configuration {
     @Override
     @JsonIgnore
     public boolean isPositive() {
+        if (isRelative()) {
+            return getSuccessRateImpact() >= 0 && getFailureRateImpact() >= 0;
+        }
         return getPassedImpact() >= 0 && getFailureImpact() >= 0 && getSkippedImpact() >= 0;
     }
 

--- a/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
@@ -155,14 +155,21 @@ class TestScoreTest {
                 }
                 """);
 
-        var builder = new TestScoreBuilder()
+        var score = new TestScoreBuilder()
                 .setName(NAME)
-                .setConfiguration(configuration);
-        var score = builder.create(createTestReport(2, 1, 7), Metric.TESTS);
+                .setConfiguration(configuration).create(createTestReport(2, 1, 7), Metric.TESTS);
         assertThat(score)
                 .hasMaxScore(100)
                 .hasImpact(-70)
                 .hasValue(30);
+
+        var max = new TestScoreBuilder()
+                .setName(NAME)
+                .setConfiguration(configuration).create(createTestReport(1, 0, 0), Metric.TESTS);
+        assertThat(max)
+                .hasMaxScore(100)
+                .hasImpact(0)
+                .hasValue(100);
     }
 
     @Test


### PR DESCRIPTION
When tests use a negative relative impact then we need to start counting from 100 minus the impact.