### PR TITLE
Set the impact to zero if the coverage is not set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <jackson-databind.version>2.18.3</jackson-databind.version>
     <analysis-model.version>13.2.0</analysis-model.version>
-    <coverage-model.version>0.53.0</coverage-model.version>
+    <coverage-model.version>0.53.1</coverage-model.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -1,12 +1,5 @@
 package edu.hm.hafner.grading;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.NoSuchElementException;
-import java.util.Properties;
-import java.util.StringJoiner;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.ParsingException;
@@ -14,6 +7,12 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.SecureXmlParserFactory;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.StringJoiner;
 
 /**
  * GitHub action entrypoint for the autograding action.
@@ -110,7 +109,7 @@ public class AutoGradingRunner {
 
             publishGradingResult(score, log);
         }
-        catch (NoSuchElementException
+        catch (IllegalArgumentException
                | ParsingException
                | SecureXmlParserFactory.ParsingException exception) {
             log.logInfo(DOUBLE_LINE);

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -66,9 +66,15 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
         this.metric = metric;
 
         var value = report.getValue(metric);
-        if (value.isPresent() && value.get() instanceof Coverage) {
-            this.coveredPercentage = ((Coverage) value.get()).getCoveredPercentage().toInt();
-            this.missedItems = ((Coverage) value.get()).getMissed();
+        if (value.isPresent() && value.get() instanceof Coverage coverage) {
+            if (coverage.isSet()) {
+                this.coveredPercentage = ((Coverage) value.get()).getCoveredPercentage().toInt();
+                this.missedItems = ((Coverage) value.get()).getMissed();
+            }
+            else {
+                this.coveredPercentage = 100; // if the coverage is not set, then assume that everything is covered
+                this.missedItems = 0;
+            }
         }
         else {
             this.coveredPercentage = 0; // If there is no coverage, then there is no code yet

--- a/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageScoreTest.java
@@ -26,6 +26,24 @@ class CoverageScoreTest {
     private static final String LINE_COVERAGE_NAME = "Line Coverage";
 
     @Test
+    void shouldIgnoreEmptyCoverage() {
+        var coverageConfiguration = createCoverageConfiguration(-1, 0);
+        var rootNode = createReport(Metric.BRANCH, "n/a");
+        var coverageScore = new CoverageScoreBuilder()
+                .setConfiguration(coverageConfiguration)
+                .create(rootNode, Metric.BRANCH);
+
+        assertThat(coverageScore)
+                .hasConfiguration(coverageConfiguration)
+                .hasMaxScore(100)
+                .hasImpact(0)
+                .hasMetric(Metric.BRANCH)
+                .hasReport(rootNode)
+                .hasCoveredPercentage(100)
+                .hasMissedPercentage(0);
+    }
+
+    @Test
     void shouldCreateInstanceAndGetProperties() {
         var coverageConfiguration = createCoverageConfiguration(1, 1);
         var rootNode = createReport(Metric.LINE, "99/100");


### PR DESCRIPTION
E.g., assignments without branches should not have a negative impact on the overall coverage score.