### PR TITLE
Remove emojis in the summary message of tests

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -164,13 +164,13 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
         summary.append(format("%2d%% successful", score.getSuccessRate()));
         var joiner = new StringJoiner(", ", " (", ")");
         if (score.hasFailures()) {
-            joiner.add(format(":x: %d failed", score.getFailedSize()));
+            joiner.add(format("%d failed", score.getFailedSize()));
         }
         if (score.hasPassedTests()) {
-            joiner.add(format(":heavy_check_mark: %d passed", score.getPassedSize()));
+            joiner.add(format("%d passed", score.getPassedSize()));
         }
         if (score.hasSkippedTests()) {
-            joiner.add(format(":see_no_evil: %d skipped", score.getSkippedSize()));
+            joiner.add(format("%d skipped", score.getSkippedSize()));
         }
         summary.append(joiner);
         return summary.toString();

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -64,7 +64,7 @@ class TestMarkdownTest {
         var testMarkdown = new TestMarkdown();
 
         assertThat(testMarkdown.createSummary(score))
-                .contains("JUnit: 100% successful (:heavy_check_mark: 999 passed)");
+                .contains("JUnit: 100% successful (999 passed)");
 
         classNode.addTestCase(builder.withTestName("Failed Test").withFailure().build());
 
@@ -73,7 +73,7 @@ class TestMarkdownTest {
                 new NodeSupplier(t -> root),
                 TestConfiguration.from(configuration));
         assertThat(testMarkdown.createSummary(almost))
-                .contains("JUnit: 99% successful (:x: 1 failed, :heavy_check_mark: 999 passed)");
+                .contains("JUnit: 99% successful (1 failed, 999 passed)");
     }
 
     @Test


### PR DESCRIPTION
The Markdown renderer of GitHub seems to have a bug when an icon is shown with emojis on the same line.

![Bildschirmfoto 2025-03-12 um 15 57 07](https://github.com/user-attachments/assets/f3c6754e-1c65-4968-bde3-69b0531bd451)
