### PR TITLE
Add support for OpenMoji

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -41,6 +41,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     private static final int MAX_SIZE = 10_000; // limit the size of the output to this number of characters
     private static final String TRUNCATION_TEXT = "\n\nToo many test failures. Grading output truncated.\n\n";
     private static final int HUNDRED_PERCENT = 100;
+    private static final String OPEN_MOJI = "openmoji:";
 
     private final String type;
     private final String icon;
@@ -229,10 +230,17 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     protected String getIcon(final S score) {
         var scoreIcon = score.getIcon();
         if (StringUtils.isNotBlank(scoreIcon)) {
-            return emoji(scoreIcon);
+            return resolveEmoji(score, scoreIcon);
         }
 
         return getToolIcon(score);
+    }
+
+    private String resolveEmoji(final S score, final String scoreIcon) {
+        if (scoreIcon.startsWith(OPEN_MOJI)) {
+            return openmoji(scoreIcon, score.getName());
+        }
+        return emoji(scoreIcon);
     }
 
     protected abstract String getToolIcon(S score);
@@ -240,13 +248,19 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     protected String getDefaultIcon(final S score) {
         var configuredIcon = score.getConfiguration().getIcon();
         if (StringUtils.isNotBlank(configuredIcon)) {
-            return emoji(configuredIcon);
+            return resolveEmoji(score, configuredIcon);
         }
         return icon;
     }
 
     protected static String emoji(final String configurationIcon) {
         return ":%s:".formatted(configurationIcon);
+    }
+
+    protected static String openmoji(final String configurationIcon, final String label) {
+        var icon = StringUtils.removeStart(configurationIcon, OPEN_MOJI);
+        return ("<img src=\"https://openmoji.org/data/color/svg/"
+                + "%s.svg\" alt=\"%s\" height=\"18\" width=\"18\">").formatted(icon, label);
     }
 
     String formatColumns(final Object... columns) {

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -445,4 +445,36 @@ class TestMarkdownTest {
                 .doesNotContain("StackTrace-100")
                 .contains("Too many test failures. Grading output truncated.");
     }
+
+    @Test
+    void shouldShowOpenMoji() {
+        var configuration = """
+                {
+                  "tests": [{
+                    "tools": [
+                      {
+                        "id": "junit",
+                        "name": "JUnit",
+                        "pattern": "target/junit.xml"
+                      }
+                    ],
+                    "name": "JUnit",
+                    "icon": "openmoji:1F6AB",
+                    "failureImpact": -1,
+                    "maxScore": 100
+                  }]
+                }
+                """;
+        var score = new AggregatedScore(LOG);
+
+        score.gradeTests(
+                new NodeSupplier(t -> TestScoreTest.createTestReport(1, 0, 0)),
+                TestConfiguration.from(configuration));
+
+        var testMarkdown = new TestMarkdown();
+
+        assertThat(testMarkdown.createDetails(score))
+                .contains("## <img src=\"https://openmoji.org/data/color/svg/1F6AB.svg\"")
+                .contains("|<img src=\"https://openmoji.org/data/color/svg/1F6AB.svg\"");
+    }
 }


### PR DESCRIPTION
See https://openmoji.org/ for a list of available emojis. In order to use such an emoji you need to use icons in the following format: "openmoji:1F6AB"

The icon name is the ID of the icon on https://openmoji.org/.