### PR TITLE
Log all errors that occur during metric conversions

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/QualityGateResult.java
+++ b/src/main/java/edu/hm/hafner/grading/QualityGateResult.java
@@ -78,7 +78,7 @@ public class QualityGateResult implements Serializable {
 
         for (var gate : qualityGates) {
             var actualValue = metrics.getOrDefault(gate.getMetric(), 0).doubleValue();
-            var evaluation = gate.evaluate(actualValue);
+            var evaluation = gate.evaluate(actualValue, log);
             evaluations.add(evaluation);
         }
 

--- a/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
+++ b/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
@@ -2,80 +2,116 @@ package edu.hm.hafner.grading;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import edu.hm.hafner.grading.QualityGate.Criticality;
+import edu.hm.hafner.util.FilteredLog;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static edu.hm.hafner.grading.assertions.Assertions.*;
 
 /**
  * Tests for {@link QualityGate}.
  */
 class QualityGateTest {
+    private static final FilteredLog LOGGER = new FilteredLog("Eeeo");
+
     @Test
     void shouldCreateQualityGate() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = createLineCoverageQualityGate();
 
-        assertThat(gate.getName()).isEqualTo("Line Coverage");
-        assertThat(gate.getMetric()).isEqualTo("line");
-        assertThat(gate.getThreshold()).isEqualTo(80.0);
-        assertThat(gate.getCriticality()).isEqualTo(QualityGate.Criticality.FAILURE);
+        assertThat(gate)
+                .hasName("Line Coverage")
+                .hasMetric("line")
+                .hasThreshold(80.0)
+                .hasCriticality(QualityGate.Criticality.FAILURE);
     }
 
     @Test
     void shouldEvaluateLineCoveragePassWithLargerValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var evaluation = gate.evaluate(85.0);
+        var gate = createLineCoverageQualityGate();
 
-        assertThat(evaluation.isPassed()).isTrue();
-        assertThat(evaluation.getActualValue()).isEqualTo(85.0);
-        assertThat(evaluation.getMessage()).contains("Line Coverage: 85.00 >= 80.00");
+        assertThat(gate.evaluate(85.0, LOGGER))
+                .isPassed()
+                .hasActualValue(85.0)
+                .hasMessage("Line Coverage: 85.00 >= 80.00");
+    }
+
+    @Test
+    void shouldEvaluateComplexityPassWithLowerValue() {
+        var gate = new QualityGate("Complexity", "cyclomatic-complexity", 80.0, Criticality.FAILURE);
+
+        assertThat(gate.evaluate(75.0, LOGGER))
+                .isPassed()
+                .hasActualValue(75.0)
+                .hasMessage("Complexity: 75.00 <= 80.00");
+    }
+
+    @Test
+    void shouldHandleInvalidMetric() {
+        var gate = new QualityGate("Line Coverage", "not-valid", 80.0, Criticality.FAILURE);
+
+        var log = new FilteredLog("Error");
+
+        assertThat(gate.evaluate(85.0, log))
+                .isPassed()
+                .hasActualValue(85.0)
+                .hasMessage("Line Coverage: 85.00 >= 80.00");
+
+        assertThat(log.getInfoMessages()).isEmpty();
+        assertThat(log.getErrorMessages())
+                .anySatisfy(message ->
+                        assertThat(message).contains("Unknown metric 'not-valid'. Assuming larger is better."))
+                .anySatisfy(message ->
+                        assertThat(message).contains("Unknown metric 'not-valid'. Using >= operator.")
+                );
     }
 
     @Test
     void shouldEvaluateLineCoverageFailWithSmallerValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var evaluation = gate.evaluate(75.0);
+        var gate = createLineCoverageQualityGate();
 
-        assertThat(evaluation.isPassed()).isFalse();
-        assertThat(evaluation.getActualValue()).isEqualTo(75.0);
-        assertThat(evaluation.getMessage()).contains("Line Coverage: 75.00 >= 80.00");
+        assertThat(gate.evaluate(75.0, LOGGER))
+                .isNotPassed()
+                .hasActualValue(75.0)
+                .hasMessage("Line Coverage: 75.00 >= 80.00");
     }
 
     @Test
     void shouldEvaluateLineCoveragePassWithEqualValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var evaluation = gate.evaluate(80.0);
+        var gate = createLineCoverageQualityGate();
 
-        assertThat(evaluation.isPassed()).isTrue();
-        assertThat(evaluation.getActualValue()).isEqualTo(80.0);
-        assertThat(evaluation.getMessage()).contains("Line Coverage: 80.00 >= 80.00");
+        assertThat(gate.evaluate(80.0, LOGGER))
+                .isPassed()
+                .hasActualValue(80.0)
+                .hasMessage("Line Coverage: 80.00 >= 80.00");
     }
 
     @Test
     void shouldSupportDifferentCriticalityLevels() {
         var gateFailure = new QualityGate("Test", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var gateUnstable = new QualityGate("Test", "line", 80.0, QualityGate.Criticality.UNSTABLE);
-
         assertThat(gateFailure.getCriticality()).isEqualTo(QualityGate.Criticality.FAILURE);
+
+        var gateUnstable = new QualityGate("Test", "line", 80.0, QualityGate.Criticality.UNSTABLE);
         assertThat(gateUnstable.getCriticality()).isEqualTo(QualityGate.Criticality.UNSTABLE);
     }
 
     @Test
-    void shouldImplementEqualsAndHashCode() {
-        var gate1 = new QualityGate("Test", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var gate2 = new QualityGate("Test", "line", 80.0, QualityGate.Criticality.FAILURE);
-        var gate3 = new QualityGate("Different", "line", 80.0, QualityGate.Criticality.FAILURE);
-
-        assertThat(gate1).isEqualTo(gate2);
-        assertThat(gate1).isNotEqualTo(gate3);
-        assertThat(gate1.hashCode()).isEqualTo(gate2.hashCode());
-    }
-
-    @Test
     void shouldImplementToString() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = createLineCoverageQualityGate();
 
         assertThat(gate.toString())
                 .contains("Line Coverage")
                 .contains("line")
                 .contains("80.00")
                 .contains("FAILURE");
+    }
+
+    private QualityGate createLineCoverageQualityGate() {
+        return new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+    }
+
+    @Test
+    void shouldAdhereToEquals() {
+        EqualsVerifier.forClass(QualityGate.class).verify();
     }
 }


### PR DESCRIPTION
When some provides an illegal metric then the grading uses default values, but does not report such problems in the logger.