### PR TITLE
Move quality gate evaluation into auto grading runner

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -107,22 +107,37 @@ public class AutoGradingRunner {
 
             logHandler.print();
 
-            publishGradingResult(score, log);
+            log.logInfo(SINGLE_LINE);
+            log.logInfo(center("Quality Gates", log));
+            log.logInfo(SINGLE_LINE);
+
+            var qualityGates = QualityGatesConfiguration.parseFromEnvironment("QUALITY_GATES", log);
+            var qualityGateResult = QualityGateResult.evaluate(score.getMetrics(), qualityGates, log);
+
+            logHandler.print();
+
+            publishGradingResult(score, qualityGateResult, log);
+            end(log, logHandler);
+
+            handleQualityGateResult(qualityGateResult, log);
         }
-        catch (IllegalArgumentException | ParsingException | SecureXmlParserFactory.ParsingException exception) {
+        catch (IllegalArgumentException | IllegalStateException | ParsingException | SecureXmlParserFactory.ParsingException exception) {
             log.logInfo(DOUBLE_LINE);
             log.logException(exception, "An error occurred while grading");
             log.logInfo(DOUBLE_LINE);
 
             publishError(score, log, exception);
+            end(log, logHandler);
         }
 
+        return score;
+    }
+
+    private void end(final FilteredLog log, final LogHandler logHandler) {
         log.logInfo(SINGLE_LINE);
         log.logInfo(center("End", log));
         log.logInfo(SINGLE_LINE);
         logHandler.print();
-
-        return score;
     }
 
     /**
@@ -187,8 +202,39 @@ public class AutoGradingRunner {
      *         the grading score
      * @param log
      *         the logger
+     * @deprecated use {@link #publishGradingResult(AggregatedScore, QualityGateResult, FilteredLog)} instead
      */
+    @Deprecated @SuppressWarnings("DeprecatedIsStillUsed")
     protected void publishGradingResult(final AggregatedScore score, final FilteredLog log) {
+        // empty default implementation
+    }
+
+    /**
+     * Publishes the grading result. This default implementation does nothing.
+     *
+     * @param score
+     *         the grading score
+     * @param qualityGateResult
+     *         the result of the quality gate evaluation
+     * @param log
+     *         the logger
+     */
+    protected void publishGradingResult(final AggregatedScore score, final QualityGateResult qualityGateResult,
+            final FilteredLog log) {
+        publishGradingResult(score, log);
+    }
+
+    /**
+     * Handles the quality gate result. This default implementation does nothing. You can override this method and throw
+     * an exception to fail the grading if the quality gate result is not successful. Note that no logging messages are
+     * printed after this method is called.
+     *
+     * @param qualityGateResult
+     *         the result of the quality gate evaluation
+     * @param log
+     *         the logger to analyze the quality gate result (readonly)
+     */
+    protected void handleQualityGateResult(final QualityGateResult qualityGateResult, final FilteredLog log) {
         // empty default implementation
     }
 


### PR DESCRIPTION
So all actions automatically participate in quality gates. If required, a runner subclass can handle failed quality gates.