### PR TITLE
Improve handling of test metrics

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -444,9 +445,15 @@ public final class AggregatedScore implements Serializable {
     }
 
     private Map<String, Integer> getTestMetrics() {
-        var tests = getTestScores().stream()
-                .map(TestScore::getTotalSize).reduce(0, Integer::sum);
-        return Map.of("tests", tests);
+        return Map.of(
+                "tests", getTestMetric(TestScore::getTotalSize),
+                "tests-success-rate", getTestMetric(TestScore::getSuccessRate),
+                "tests-failure-rate", getTestMetric(TestScore::getFailureRate));
+    }
+
+    private Integer getTestMetric(final Function<TestScore, Integer> metric) {
+        return getTestScores().stream()
+                .map(metric).reduce(0, Integer::sum);
     }
 
     private Map<String, Integer> getSoftwareMetrics() {

--- a/src/main/java/edu/hm/hafner/grading/QualityGatesConfiguration.java
+++ b/src/main/java/edu/hm/hafner/grading/QualityGatesConfiguration.java
@@ -152,7 +152,7 @@ public final class QualityGatesConfiguration {
                 return PARSER_REGISTRY.get(metric).getName();
             }
 
-            return Metric.fromTag(metric).getDisplayName();
+            return Metric.fromName(metric).getDisplayName();
         }
 
         // Getters for Jackson (required for deserialization)

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -126,7 +126,7 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
     }
 
     private int getRateOf(final int achieved) {
-        return Math.toIntExact(Math.round(achieved * 100.0 / getTotalSize()));
+        return Math.toIntExact(Math.round(achieved * 100.0 / (getTotalSize() - getSkippedSize())));
     }
 
     public int getPassedSize() {

--- a/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
@@ -447,6 +447,8 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
                 entry("npath-complexity", 0),
                 entry("cognitive-complexity", 100),
                 entry("tests", 22),
+                entry("tests-success-rate", 26),
+                entry("tests-failure-rate", 74),
                 entry("branch", 60),
                 entry("line", 80),
                 entry("mutation", 60),

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -659,7 +659,7 @@ class AutoGradingRunnerITest extends ResourceTest {
     private static class StringCommentBuilder extends CommentBuilder {
         private final List<String> comments = new ArrayList<>();
 
-        public List<String> getComments() {
+        private List<String> getComments() {
             return comments;
         }
 

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -121,7 +121,7 @@ class GradingReportTest {
                 "img title=\"Score percentage: 33%\"",
                 "percentages/033.svg",
                 "# :mortar_board: &nbsp; Summary - 167 of 500",
-                "Integrationstests - 27 of 100: 42% successful",
+                "Integrationstests - 27 of 100: 56% successful",
                 "Modultests - 50 of 100:  0% successful",
                 "Line Coverage - 60 of 100", "80% (20 missed lines)",
                 "Branch Coverage - 20 of 100", "60% (40 missed branches)",
@@ -165,7 +165,7 @@ class GradingReportTest {
                 .doesNotContain("JUnit Tests", "Code Coverage", "Style");
 
         assertThat(results.getMarkdownSummary(score, "Summary")).contains(
-                "Integrationstests: 42% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests: 56% successful", "4 failed", "5 passed", "3 skipped",
                 "Modultests:  0% successful", "10 failed",
                 "Line Coverage: 80% (20 missed lines)",
                 "Branch Coverage: 60% (40 missed branches)",
@@ -248,6 +248,8 @@ class GradingReportTest {
 
         assertThat(aggregation.getMetrics()).containsOnly(
                 entry("tests", 22),
+                entry("tests-success-rate", 26),
+                entry("tests-failure-rate", 74),
                 entry("branch", 60),
                 entry("line", 80),
                 entry("mutation", 60),
@@ -258,7 +260,7 @@ class GradingReportTest {
 
         assertThat(results.getMarkdownSummary(aggregation, "Summary")).contains(
                 "## :sunny: &nbsp; Summary",
-                "Integrationstests: 42% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests: 56% successful", "4 failed", "5 passed", "3 skipped",
                 "Modultests:  0% successful", "10 failed",
                 "Branch Coverage: 60% (40 missed branches)",
                 "Mutation Coverage: 60% (40 survived mutations)",

--- a/src/test/java/edu/hm/hafner/grading/QualityGateEvaluationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/QualityGateEvaluationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 import edu.hm.hafner.grading.QualityGate.Criticality;
+import edu.hm.hafner.grading.QualityGateResult.OverallStatus;
 import edu.hm.hafner.util.FilteredLog;
 
 import java.util.List;
@@ -27,12 +28,12 @@ class QualityGateEvaluationTest {
 
         assertThat(result).isSuccessful()
                 .hasSuccessCount(1).hasFailureCount(0)
-                .hasOverallStatus(QualityGateResult.OverallStatus.SUCCESS);
+                .hasOverallStatus(OverallStatus.SUCCESS);
 
         var evaluation = result.getEvaluations().get(0);
         assertThat(evaluation).isPassed()
                 .hasActualValue(85.0)
-                .hasCriticality(QualityGate.Criticality.FAILURE)
+                .hasCriticality(Criticality.FAILURE)
                 .hasMessage("Line Coverage: 85.00 >= 80.00")
                 .hasGateName(qualityGate.getName())
                 .hasMetric(qualityGate.getMetric())
@@ -55,14 +56,14 @@ class QualityGateEvaluationTest {
         var result = QualityGateResult.evaluate(metrics, List.of(qualityGate), log);
 
         assertThat(result).isNotSuccessful()
-                .hasOverallStatus(QualityGateResult.OverallStatus.FAILURE)
+                .hasOverallStatus(OverallStatus.FAILURE)
                 .hasSuccessCount(0)
                 .hasFailureCount(1);
 
         var evaluation = result.getEvaluations().get(0);
         assertThat(evaluation).isNotPassed()
                 .hasActualValue(75.0)
-                .hasCriticality(QualityGate.Criticality.FAILURE)
+                .hasCriticality(Criticality.FAILURE)
                 .hasMessage("Line Coverage: 75.00 >= 80.00")
                 .hasGateName(qualityGate.getName())
                 .hasMetric(qualityGate.getMetric())
@@ -86,7 +87,7 @@ class QualityGateEvaluationTest {
         assertThat(result).isSuccessful()
                 .hasSuccessCount(0)
                 .hasFailureCount(0)
-                .hasOverallStatus(QualityGateResult.OverallStatus.SUCCESS);
+                .hasOverallStatus(OverallStatus.SUCCESS);
 
         assertThat(log.getInfoMessages()).map(String::strip)
                 .containsSubsequence("No quality gates to evaluate");
@@ -100,8 +101,8 @@ class QualityGateEvaluationTest {
         );
 
         var qualityGates = List.of(
-                new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE),
-                new QualityGate("Branch Coverage", "branch", 60.0, QualityGate.Criticality.UNSTABLE)
+                new QualityGate("Line Coverage", "line", 80.0, Criticality.FAILURE),
+                new QualityGate("Branch Coverage", "branch", 60.0, Criticality.UNSTABLE)
         );
 
         var log = new FilteredLog("Test");
@@ -110,7 +111,7 @@ class QualityGateEvaluationTest {
         assertThat(result).isSuccessful()
                 .hasSuccessCount(2)
                 .hasFailureCount(0)
-                .hasOverallStatus(QualityGateResult.OverallStatus.SUCCESS);
+                .hasOverallStatus(OverallStatus.SUCCESS);
 
         assertThat(log.getInfoMessages()).map(String::strip)
                 .containsSubsequence("Evaluating 2 quality gate(s)",

--- a/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
+++ b/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
@@ -85,11 +85,20 @@ class QualityGateTest {
     }
 
     @Test
-    void shouldFailFastForUnknownMetrics() {
-        var gate = new QualityGate("Unknown", "unknown", 0.0, Criticality.UNSTABLE);
+    void shouldUseLessThanForUnknownMetrics() {
+        var gate = new QualityGate("Unknown", "unknown", 1.0, Criticality.UNSTABLE);
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> gate.evaluate(42.0))
-                .withMessage("No metric found for name 'unknown'");
+        assertThat(gate.evaluate(0)).isPassed();
+        assertThat(gate.evaluate(1)).isPassed();
+        assertThat(gate.evaluate(2)).isNotPassed();
+    }
+
+    @Test
+    void shouldUseGreaterThanForRates() {
+        var gate = new QualityGate("Unknown", "tests-success-rate", 99, Criticality.UNSTABLE);
+
+        assertThat(gate.evaluate(100)).isPassed();
+        assertThat(gate.evaluate(99)).isPassed();
+        assertThat(gate.evaluate(98)).isNotPassed();
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
+++ b/src/test/java/edu/hm/hafner/grading/QualityGateTest.java
@@ -16,13 +16,13 @@ import static edu.hm.hafner.grading.assertions.Assertions.*;
 class QualityGateTest {
     @Test
     void shouldCreateQualityGate() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = new QualityGate("Line Coverage", "line", 80.0, Criticality.FAILURE);
 
         assertThat(gate)
                 .hasName("Line Coverage")
                 .hasMetric("line")
                 .hasThreshold(80.0)
-                .hasCriticality(QualityGate.Criticality.FAILURE);
+                .hasCriticality(Criticality.FAILURE);
         assertThat(gate.toString())
                 .contains("Line Coverage")
                 .contains("line")
@@ -32,7 +32,7 @@ class QualityGateTest {
 
     @Test
     void shouldEvaluateLineCoveragePassWithLargerValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = new QualityGate("Line Coverage", "line", 80.0, Criticality.FAILURE);
         var evaluation = gate.evaluate(85.0);
 
         assertThat(evaluation).isPassed().hasActualValue(85.0);
@@ -41,7 +41,7 @@ class QualityGateTest {
 
     @Test
     void shouldEvaluateLineCoverageFailWithSmallerValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = new QualityGate("Line Coverage", "line", 80.0, Criticality.FAILURE);
         var evaluation = gate.evaluate(75.0);
 
         assertThat(evaluation).isNotPassed().hasActualValue(75.0);
@@ -50,7 +50,7 @@ class QualityGateTest {
 
     @Test
     void shouldEvaluateLineCoveragePassWithEqualValue() {
-        var gate = new QualityGate("Line Coverage", "line", 80.0, QualityGate.Criticality.FAILURE);
+        var gate = new QualityGate("Line Coverage", "line", 80.0, Criticality.FAILURE);
         var evaluation = gate.evaluate(80.0);
 
         assertThat(evaluation).isPassed().hasActualValue(80.0);
@@ -72,7 +72,7 @@ class QualityGateTest {
     }
 
     @ParameterizedTest(name = "Criticality: {0}")
-    @EnumSource(QualityGate.Criticality.class)
+    @EnumSource(Criticality.class)
     void shouldSupportDifferentCriticalityLevels(final Criticality criticality) {
         var gateFailure = new QualityGate("Test", "line", 80.0, criticality);
 

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -187,7 +187,7 @@ class TestMarkdownTest {
                 .contains("|JUnit|1|5|3|4|12|27")
                 .contains(IMPACT_CONFIGURATION);
         assertThat(testMarkdown.createSummary(score))
-                .contains("JUnit - 27 of 100", "42% successful", "4 failed", "5 passed", "3 skipped");
+                .contains("JUnit - 27 of 100", "56% successful", "4 failed", "5 passed", "3 skipped");
     }
 
     @Test
@@ -268,7 +268,7 @@ class TestMarkdownTest {
                         "- test-class-skipped-1#test-skipped-1",
                         "- test-class-skipped-2#test-skipped-2");
         assertThat(testMarkdown.createSummary(score)).contains(
-                "Integrationstests - 27 of 100: 42% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests - 27 of 100: 56% successful", "4 failed", "5 passed", "3 skipped",
                 "Modultests - 50 of 100:  0% successful", "10 failed");
     }
 
@@ -312,7 +312,7 @@ class TestMarkdownTest {
                 .doesNotContain(IMPACT_CONFIGURATION)
                 .doesNotContain("Impact");
         assertThat(testMarkdown.createSummary(score)).contains(
-                "Integrationstests: 42% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests: 56% successful", "4 failed", "5 passed", "3 skipped",
                 "Modultests:  0% successful", "10 failed");
     }
 
@@ -408,8 +408,8 @@ class TestMarkdownTest {
                         "```text StackTrace-1```",
                         "```text StackTrace-2```");
         assertThat(testMarkdown.createSummary(score)).contains(
-                "Integrationstests 1 - 23 of 100", "42% successful", "4 failed", "5 passed", "3 skipped",
-                "Integrationstests 2 - 23 of 100", "42% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests 1 - 23 of 100", "56% successful", "4 failed", "5 passed", "3 skipped",
+                "Integrationstests 2 - 23 of 100", "56% successful", "4 failed", "5 passed", "3 skipped",
                 "Modultests 1 - 70 of 100", "0% successful", "10 failed",
                 "Modultests 2 - 70 of 100", "0% successful", "10 failed");
     }

--- a/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestScoreTest.java
@@ -45,15 +45,15 @@ class TestScoreTest {
                 .hasName(NAME).hasConfiguration(configuration)
                 .hasFailedSize(5).hasSkippedSize(3).hasTotalSize(10)
                 .hasMaxScore(100)
-                .hasImpact(20)
-                .hasValue(20);
+                .hasImpact(29)
+                .hasValue(29);
         assertThat(twenty.toString()).startsWith("{").endsWith("}")
-                .containsIgnoringWhitespaces("\"impact\":20");
+                .containsIgnoringWhitespaces("\"impact\":29");
 
         assertThat(builder.create(createTestReport(12, 3, 5), Metric.TESTS))
-                .hasImpact(60).hasValue(60);
+                .hasImpact(71).hasValue(71);
         assertThat(builder.create(createTestReport(95, 5, 0), Metric.TESTS))
-                .hasImpact(95).hasValue(95);
+                .hasImpact(100).hasValue(100);
         assertThat(builder.create(createTestReport(100, 0, 0), Metric.TESTS))
                 .hasImpact(100).hasValue(100);
 
@@ -95,13 +95,13 @@ class TestScoreTest {
                 .hasName(NAME).hasConfiguration(configuration)
                 .hasFailedSize(5).hasSkippedSize(3).hasTotalSize(10)
                 .hasMaxScore(50)
-                .hasImpact(10)
-                .hasValue(10);
+                .hasImpact(15)
+                .hasValue(15);
 
         assertThat(builder.create(createTestReport(12, 3, 5), Metric.TESTS))
-                .hasImpact(30).hasValue(30);
+                .hasImpact(36).hasValue(36);
         assertThat(builder.create(createTestReport(95, 5, 0), Metric.TESTS))
-                .hasImpact(48).hasValue(48);
+                .hasImpact(50).hasValue(50);
         assertThat(builder.create(createTestReport(100, 0, 0), Metric.TESTS))
                 .hasImpact(50).hasValue(50);
     }
@@ -133,8 +133,8 @@ class TestScoreTest {
                 .hasName(NAME).hasConfiguration(configuration)
                 .hasFailedSize(5).hasSkippedSize(3).hasTotalSize(10)
                 .hasMaxScore(200)
-                .hasImpact(40)
-                .hasValue(40);
+                .hasImpact(58)
+                .hasValue(58);
     }
 
     @Test
@@ -160,8 +160,8 @@ class TestScoreTest {
                 .setConfiguration(configuration).create(createTestReport(2, 1, 7), Metric.TESTS);
         assertThat(score)
                 .hasMaxScore(100)
-                .hasImpact(-70)
-                .hasValue(30);
+                .hasImpact(-78)
+                .hasValue(22);
 
         var max = new TestScoreBuilder()
                 .setName(NAME)


### PR DESCRIPTION
Do not include skipped tests in success rate. This fixes #465.

Additionally, add the new metrics `tests-success-rate` and `tests-failure-rate` to the metrics summary. These metrics are required to create quality gates for tests.

Also make sure that unknown metrics do not fail the build as static analysis warnings may use an aggregation.