### PR TITLE
Add status icon column for test results

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -34,6 +34,8 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static final String LEDGER = ":heavy_minus_sign:";
     static final String IMPACT = ":moneybag:";
     static final String TOTAL = ":heavy_minus_sign:";
+    static final String CHECK = ":white_check_mark:";
+    static final String CROSS = ":x:";
     static final String EMPTY = ":heavy_minus_sign:";
     static final int DEFAULT_PERCENTAGE_SIZE = 110;
 

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -33,7 +33,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
     }
 
     @Override
-    @SuppressWarnings("checkstyle:LambdaBodyLength")
+    @SuppressWarnings({"checkstyle:LambdaBodyLength", "PMD.CognitiveComplexity"})
     protected String createSpecificDetails(final List<TestScore> scores) {
         var total = new StringBuilder();
         for (TestScore score : scores) {
@@ -42,15 +42,15 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                     .addParagraph()
                     .addText(getPercentageImage(score))
                     .addNewline()
-                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Tests", "Success %", "Failure %"),
+                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Tests", "Success %", "Failure %", "Complete"),
                             score.getConfiguration().isRelative())
-                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Passed", "Skipped", "Failed", "Tests"),
+                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Passed", "Skipped", "Failed", "Tests", "Complete"),
                             !score.getConfiguration().isRelative())
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
-                    .addTextIf(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:"),
-                            score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:", ":-:"),
+                            score.getConfiguration().isRelative())
+                    .addTextIf(formatColumns(":-:", ":-:", ":-:", ":-:", ":-:", ":-:", ":-:", ":-:"),
                             !score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(":-:"), score.hasMaxScore())
                     .addNewline();
@@ -62,7 +62,8 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                             String.valueOf(subScore.getReportFiles()),
                             String.valueOf(subScore.getTotalSize()),
                             String.valueOf(subScore.getSuccessRate()),
-                            String.valueOf(subScore.getFailureRate())),
+                            String.valueOf(subScore.getFailureRate()),
+                            subScore.isComplete() ? CHECK : CROSS),
                             score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(
                             getIcon(subScore),
@@ -71,7 +72,8 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                             String.valueOf(subScore.getPassedSize()),
                             String.valueOf(subScore.getSkippedSize()),
                             String.valueOf(subScore.getFailedSize()),
-                            String.valueOf(subScore.getTotalSize())),
+                            String.valueOf(subScore.getTotalSize()),
+                            subScore.isComplete() ? CHECK : CROSS),
                             !score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(String.valueOf(subScore.getImpact())), score.hasMaxScore())
                     .addNewline());
@@ -107,6 +109,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                                 renderImpact(configuration.getSuccessRateImpact()),
                                 renderImpact(configuration.getFailureRateImpact())),
                                 configuration.isRelative())
+                        .addText(formatColumns(EMPTY))
                         .addText(formatColumns(LEDGER))
                         .addNewline();
             }

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -33,7 +33,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:LambdaBodyLength", "PMD.CognitiveComplexity"})
+    @SuppressWarnings("checkstyle:LambdaBodyLength")
     protected String createSpecificDetails(final List<TestScore> scores) {
         var total = new StringBuilder();
         for (TestScore score : scores) {
@@ -42,9 +42,9 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                     .addParagraph()
                     .addText(getPercentageImage(score))
                     .addNewline()
-                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Tests", "Success %", "Failure %", "Complete"),
+                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Tests", "Success %", "Failure %", "Status"),
                             score.getConfiguration().isRelative())
-                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Passed", "Skipped", "Failed", "Tests", "Complete"),
+                    .addTextIf(formatColumns("Icon", "Name", "Reports", "Passed", "Skipped", "Failed", "Tests", "Status"),
                             !score.getConfiguration().isRelative())
                     .addTextIf(formatColumns("Impact"), score.hasMaxScore())
                     .addNewline()
@@ -63,7 +63,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                             String.valueOf(subScore.getTotalSize()),
                             String.valueOf(subScore.getSuccessRate()),
                             String.valueOf(subScore.getFailureRate()),
-                            subScore.isComplete() ? CHECK : CROSS),
+                            getSuccessIcon(!subScore.hasFailures())),
                             score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(
                             getIcon(subScore),
@@ -73,7 +73,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                             String.valueOf(subScore.getSkippedSize()),
                             String.valueOf(subScore.getFailedSize()),
                             String.valueOf(subScore.getTotalSize()),
-                            subScore.isComplete() ? CHECK : CROSS),
+                            getSuccessIcon(!subScore.hasFailures())),
                             !score.getConfiguration().isRelative())
                     .addTextIf(formatColumns(String.valueOf(subScore.getImpact())), score.hasMaxScore())
                     .addNewline());
@@ -217,5 +217,9 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
     @Override
     protected String getToolIcon(final TestScore score) {
         return getDefaultIcon(score); // no customizations for test scores
+    }
+
+    protected String getSuccessIcon(final boolean successful) {
+        return successful ? CHECK : CROSS;
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -219,7 +219,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
         return getDefaultIcon(score); // no customizations for test scores
     }
 
-    protected String getSuccessIcon(final boolean successful) {
+    private String getSuccessIcon(final boolean successful) {
         return successful ? CHECK : CROSS;
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -199,15 +199,6 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
         return hasSkippedTests() || hasFailures() || hasPassedTests();
     }
 
-    /**
-     * Returns whether all tests passed.
-     *
-     * @return {@code true} if all tests passed, {@code false} otherwise
-     */
-    public boolean isComplete() {
-        return getPassedSize() >= getTotalSize() - getSkippedSize();
-    }
-
     private List<TestCase> filterTests(final TestResult result) {
         return getReport().getTestCases().stream()
                 .filter(testCase -> testCase.getResult() == result).collect(Collectors.toList());

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -199,6 +199,15 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
         return hasSkippedTests() || hasFailures() || hasPassedTests();
     }
 
+    /**
+     * Returns whether all tests passed.
+     *
+     * @return {@code true} if all tests passed, {@code false} otherwise
+     */
+    public boolean isComplete() {
+        return getPassedSize() >= getTotalSize() - getSkippedSize();
+    }
+
     private List<TestCase> filterTests(final TestResult result) {
         return getReport().getTestCases().stream()
                 .filter(testCase -> testCase.getResult() == result).collect(Collectors.toList());

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 class TestMarkdownTest {
-    private static final String IMPACT_CONFIGURATION = ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*10*|*-1*|*-5*|:heavy_minus_sign:|:heavy_minus_sign:";
+    private static final String IMPACT_CONFIGURATION = ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*10*|*-1*|*-5*|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:";
     private static final FilteredLog LOG = new FilteredLog("Test");
     private static final int TOO_MANY_FAILURES = 400;
 
@@ -146,7 +146,7 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 35 of 100")
-                .contains("|:custom-icon:|JUnit|3|24|0|13|37|-65")
+                .contains("|:custom-icon:|JUnit|3|24|0|13|37|:x:|-65")
                 .contains("__Aufgabe3Test:shouldSplitToEmptyRight(int)[1]__")
                 .containsPattern("```text\\n *Expected size: 3 but was: 5 in:")
                 .contains("__edu.hm.hafner.grading.ReportFinderTest:shouldFindTestReports__");
@@ -184,7 +184,7 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 27 of 100")
-                .contains("|JUnit|1|5|3|4|12|27")
+                .contains("|JUnit|1|5|3|4|12|:x:|27")
                 .contains(IMPACT_CONFIGURATION);
         assertThat(testMarkdown.createSummary(score))
                 .contains("JUnit - 27 of 100", "56% successful", "4 failed", "5 passed", "3 skipped");
@@ -218,8 +218,8 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 100 of 100")
-                .contains("|JUnit|1|23|100|0|0")
-                .contains(":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|*-*|*-1*|:heavy_minus_sign:");
+                .contains("|JUnit|1|23|100|0|:white_check_mark:|0")
+                .contains(":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:|*-*|*-1*|:heavy_minus_sign:|:heavy_minus_sign:");
         assertThat(testMarkdown.createSummary(score))
                 .contains("JUnit - 100 of 100", "100% successful", "23 passed");
         assertThat(score.getAchievedScore()).isEqualTo(100);
@@ -259,8 +259,8 @@ class TestMarkdownTest {
 
         assertThat(testMarkdown.createDetails(score))
                 .contains("JUnit - 77 of 100",
-                        "|Integrationstests|1|5|3|4|12|27",
-                        "|Modultests|1|0|0|10|10|-50",
+                        "|Integrationstests|1|5|3|4|12|:x:|27",
+                        "|Modultests|1|0|0|10|10|:x:|-50",
                         IMPACT_CONFIGURATION,
                         "**Total**|**:heavy_minus_sign:**|**2**|**5**|**3**|**14**|**22**|**-23**",
                         "### Skipped Tests",
@@ -388,15 +388,15 @@ class TestMarkdownTest {
         assertThat(testMarkdown.createDetails(score))
                 .containsIgnoringWhitespaces(
                         "One - 46 of 100",
-                        "|Integrationstests 1|1|5|3|4|12|23",
-                        "|Integrationstests 2|1|5|3|4|12|23",
+                        "|Integrationstests 1|1|5|3|4|12|:x:|23",
+                        "|Integrationstests 2|1|5|3|4|12|:x:|23",
                         "|**Total**|**:heavy_minus_sign:**|**2**|**10**|**6**|**8**|**24**|**46**",
                         "Two - 40 of 100",
-                        "|Modultests 1|1|0|0|10|10|-30",
-                        "|Modultests 2|1|0|0|10|10|-30",
+                        "|Modultests 1|1|0|0|10|10|:x:|-30",
+                        "|Modultests 2|1|0|0|10|10|:x:|-30",
                         "|**Total**|**:heavy_minus_sign:**|**2**|**0**|**0**|**20**|**20**|**-60**",
-                        ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*1*|*2*|*3*|:heavy_minus_sign:|:heavy_minus_sign:",
-                        ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:",
+                        ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*1*|*2*|*3*|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:",
+                        ":moneybag:|:heavy_minus_sign:|:heavy_minus_sign:|*-1*|*-2*|*-3*|:heavy_minus_sign:|:heavy_minus_sign:|:heavy_minus_sign:",
                         "__test-class-failed-0:test-failed-0__",
                         "__test-class-failed-1:test-failed-1__",
                         "__test-class-failed-2:test-failed-2__",


### PR DESCRIPTION
Added a summary icon column for the overall test results.

I named the column “Complete” because I thought it would be more appropriate for ✅ and ❌.

Will fix #503 