### PR TITLE
Fix display name of scope

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -44,7 +44,7 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
                     .addNewline();
 
             score.getSubScores().forEach(subScore -> details
-                    .addText(formatColumns(getIcon(subScore), subScore.getName(), getScope(subScore),
+                    .addText(formatColumns(getIcon(subScore), subScore.getName(), subScore.getScope().getDisplayName(),
                             String.valueOf(subScore.getTotalSize())))
                     .addTextIf(formatColumns(String.valueOf(subScore.getImpact())), score.hasMaxScore())
                     .addNewline());

--- a/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java
@@ -51,7 +51,7 @@ abstract class CoverageMarkdown extends ScoreMarkdown<CoverageScore, CoverageCon
                     .addNewline();
 
             score.getSubScores().forEach(subScore -> details
-                    .addText(formatColumns(getIcon(subScore), subScore.getName(), getScope(subScore),
+                    .addText(formatColumns(getIcon(subScore), subScore.getName(), subScore.getScope().getDisplayName(),
                             String.valueOf(subScore.getCoveredPercentage())))
                     .addTextIf(formatColumns(subScore.getImpact()), score.hasMaxScore())
                     .addNewline());

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -1,5 +1,7 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.analysis.FileReaderFactory;
 import edu.hm.hafner.analysis.IssuesInModifiedCodeMarker;
 import edu.hm.hafner.analysis.ParsingException;
@@ -12,7 +14,6 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -121,7 +122,7 @@ public final class FileSystemToolParser implements ToolParser {
         }
         else {
             var aggregation = Node.merge(nodes);
-            log.logInfo("-> %s (%s) Total: %s", getDisplayName(tool), tool.getScope().toString(), extractMetric(tool, aggregation));
+            log.logInfo("-> %s (%s) Total: %s", getDisplayName(tool), tool.getScope().getDisplayName(), extractMetric(tool, aggregation));
             // Wrap the node into a container with the specified tool name
             var containerNode = createEmptyContainer(tool);
             containerNode.addChild(aggregation);

--- a/src/main/java/edu/hm/hafner/grading/MetricMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricMarkdown.java
@@ -52,7 +52,7 @@ public class MetricMarkdown extends ScoreMarkdown<MetricScore, MetricConfigurati
 
     private String createMetricRow(final MetricScore score) {
         if (score.getReport().getValue(score.getMetric()).isEmpty()) {
-            return formatColumns(getIcon(score), score.getName(), getScope(score), N_A, N_A, N_A, N_A, N_A)
+            return formatColumns(getIcon(score), score.getName(), score.getScope().getDisplayName(), N_A, N_A, N_A, N_A, N_A)
                     + LINE_BREAK;
         }
         return createRow(score) + LINE_BREAK;
@@ -67,10 +67,10 @@ public class MetricMarkdown extends ScoreMarkdown<MetricScore, MetricConfigurati
                 .map(Value::asDouble)
                 .forEach(stats::addValue);
         if (stats.getN() == 0) {
-            return formatColumns(getIcon(score), score.getName(), getScope(score), score.getMetricValueAsString(),
+            return formatColumns(getIcon(score), score.getName(), score.getScope().getDisplayName(), score.getMetricValueAsString(),
                     N_A, N_A, N_A, N_A);
         }
-        return formatColumns(getIcon(score), score.getName(), getScope(score), score.getMetricValueAsString(),
+        return formatColumns(getIcon(score), score.getName(), score.getScope().getDisplayName(), score.getMetricValueAsString(),
                 metric.format(Locale.ENGLISH, stats.getMin()),
                 metric.format(Locale.ENGLISH, stats.getMax()),
                 metric.formatMean(Locale.ENGLISH, stats.getMean()),

--- a/src/main/java/edu/hm/hafner/grading/Scope.java
+++ b/src/main/java/edu/hm/hafner/grading/Scope.java
@@ -30,7 +30,7 @@ public enum Scope {
             case String s when s.isBlank() -> PROJECT;
             case String s when Strings.CI.containsAny(s, "project", "all") -> PROJECT;
             case String s when Strings.CI.contains(s, "files") -> MODIFIED_FILES;
-            case String s when Strings.CI.containsAny(s, "lines", "code") -> MODIFIED_LINES;
+            case String s when Strings.CI.containsAny(s, "lines", "code", "new") -> MODIFIED_LINES;
             default -> throw new IllegalArgumentException("No such scope available: " + value);
         };
     }

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -1,9 +1,11 @@
 package edu.hm.hafner.grading;
 
-import com.google.errorprone.annotations.FormatMethod;
-import edu.hm.hafner.grading.TruncatedString.TruncatedStringBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+import edu.hm.hafner.grading.TruncatedString.TruncatedStringBuilder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -161,7 +163,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
 
     protected String getScopeTitle(final S score, final int size) {
         return "#".repeat(size)
-                + " %s &nbsp; %s (%s)".formatted(getIcon(score), score.getName(), getScope(score))
+                + " %s &nbsp; %s (%s)".formatted(getIcon(score), score.getName(), score.getScope().getDisplayName())
                 + createScoreTitle(score);
     }
 
@@ -208,10 +210,6 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
         return icon;
     }
 
-    protected String getScope(final S score) {
-        return score.getScope().toString().replace("_", " ");
-    }
-
     protected static String emoji(final String configurationIcon) {
         return ":%s:".formatted(configurationIcon);
     }
@@ -226,6 +224,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
         return format(i -> i, columns);
     }
 
+    @Deprecated(since = "10.1.0", forRemoval = true)
     String formatItalicColumns(final Object... columns) {
         return format(s -> "*" + s + "*", columns);
     }
@@ -269,6 +268,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
                 .collect(Collectors.joining("|", "|", ""));
     }
 
+    @Deprecated(since = "10.1.0", forRemoval = true)
     protected String renderImpact(final int impact) {
         if (impact == 0) {
             return N_A;

--- a/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/TestMarkdown.java
@@ -59,7 +59,7 @@ public class TestMarkdown extends ScoreMarkdown<TestScore, TestConfiguration> {
                     .addText(formatColumns(
                             getIcon(subScore),
                             subScore.getName(),
-                            getScope(subScore),
+                            subScore.getScope().getDisplayName(),
                             String.valueOf(subScore.getTotalSize())
                     ))
                     .addTextIf(formatColumns(


### PR DESCRIPTION
The display name of the scope should always be used when the scope is rendered. 