### PR TITLE
Add missing scope in analysis scores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-model</artifactId>
-  <version>10.2.0-SNAPSHOT</version>
+  <version>10.1.1-SNAPSHOT</version>
   <name>Autograding Model</name>
 
   <description>This module autogrades Java projects based on a configurable set of metrics.</description>

--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -410,18 +410,18 @@ public final class AggregatedScore implements Serializable {
 
     private void logSubResult(final Score<?, ?> score) {
         if (!score.hasMaxScore()) {
-            log.logInfo("=> %s: %s", score.getName(), score.createSummary());
+            log.logInfo("=> %s: %s [%s]", score.getName(), score.createSummary(), score.getScope().getDisplayName());
         }
     }
 
     private void logResult(final Configuration subConfiguration, final Score<?, ?> score) {
         if (score.hasMaxScore()) {
-            log.logInfo("=> %s Score: %d of %d",
-                    subConfiguration.getName(), score.getValue(), score.getMaxScore());
+            log.logInfo("=> %s Score: %d of %d [%s]",
+                    subConfiguration.getName(), score.getValue(), score.getMaxScore(), score.getScope().getDisplayName());
         }
         else {
-            log.logInfo("=> %s: %s",
-                    subConfiguration.getName(), score.createSummary());
+            log.logInfo("=> %s: %s [%s]",
+                    subConfiguration.getName(), score.createSummary(), score.getScope().getDisplayName());
         }
     }
 

--- a/src/main/java/edu/hm/hafner/grading/Configuration.java
+++ b/src/main/java/edu/hm/hafner/grading/Configuration.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import one.util.streamex.StreamEx;
 
 /**
@@ -121,6 +123,10 @@ public abstract class Configuration implements Serializable {
                 getName(), "No tools configured.", toString());
 
         tools.forEach(this::validate);
+
+        var scopes = tools.stream().map(ToolConfiguration::getScope).collect(Collectors.toSet());
+        Ensure.that(scopes.size() == 1).isTrue("%s: %s%n%s",
+                getName(), "All tools must have the same scope, but found: " + Set.copyOf(scopes), toString());
     }
 
     /**
@@ -138,7 +144,7 @@ public abstract class Configuration implements Serializable {
      *         if this configuration is invalid
      */
     protected void validate() {
-        // default implementation does nothing
+        // the default implementation does nothing
     }
 
     /**
@@ -152,7 +158,7 @@ public abstract class Configuration implements Serializable {
      *         if this configuration is invalid
      */
     protected void validate(final ToolConfiguration tool) {
-        // default implementation does nothing
+        // the default implementation does nothing
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/grading/MetricStatistics.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricStatistics.java
@@ -158,7 +158,7 @@ public class MetricStatistics {
     private Value getValue(final String id, final Scope scope) {
         var values = getValues(scope);
         if (!values.containsKey(id)) {
-            throw new NoSuchElementException("Metric " + id + " is not available in " + this);
+            throw new NoSuchElementException("Metric " + id + " is not available in scope " + scope + " : " + this);
         }
         return values.get(id);
     }

--- a/src/main/java/edu/hm/hafner/grading/Scope.java
+++ b/src/main/java/edu/hm/hafner/grading/Scope.java
@@ -29,7 +29,7 @@ public enum Scope {
         return switch (value) {
             case String s when s.isBlank() -> PROJECT;
             case String s when Strings.CI.containsAny(s, "project", "all") -> PROJECT;
-            case String s when Strings.CI.contains(s, "files") -> MODIFIED_FILES;
+            case String s when Strings.CI.containsAny(s, "files", "changed") -> MODIFIED_FILES;
             case String s when Strings.CI.containsAny(s, "lines", "code", "new") -> MODIFIED_LINES;
             default -> throw new IllegalArgumentException("No such scope available: " + value);
         };

--- a/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
@@ -1,13 +1,15 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.coverage.Metric;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -173,6 +175,7 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
 
         setName(StringUtils.defaultIfBlank(tool.getName(), report.getName()));
         setIcon(tool.getIcon());
+        setScope(tool.getScope());
     }
 
     Node getNode() {

--- a/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
@@ -373,8 +373,8 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
         assertThat(logger.getErrorMessages()).isEmpty();
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 2 static analysis configuration(s)",
-                "=> Style Score: 30 of 100",
-                "=> Bugs Score: 0 of 100");
+                "=> Style Score: 30 of 100 [Whole Project]",
+                "=> Bugs Score: 0 of 100 [Whole Project]");
 
         aggregation.gradeTests(
                 new NodeSupplier(TestMarkdownTest::createTwoReports),
@@ -394,7 +394,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
         assertThat(logger.getErrorMessages()).isEmpty();
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 1 test configuration(s)",
-                "=> JUnit Score: 77 of 100");
+                "=> JUnit Score: 77 of 100 [Whole Project]");
 
         aggregation.gradeCoverage(
                 new NodeSupplier(CoverageMarkdownTest::createTwoReports),
@@ -414,8 +414,8 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
         assertThat(logger.getErrorMessages()).isEmpty();
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 2 coverage configuration(s)",
-                "=> JaCoCo Score: 40 of 100",
-                "=> PIT Score: 20 of 100");
+                "=> JaCoCo Score: 40 of 100 [Whole Project]",
+                "=> PIT Score: 20 of 100 [Whole Project]");
 
         aggregation.gradeMetrics(
                 new NodeSupplier(MetricMarkdownTest::createNodes),
@@ -435,10 +435,10 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
         assertThat(logger.getErrorMessages()).isEmpty();
         assertThat(String.join("\n", logger.getInfoMessages())).contains(
                 "Processing 1 metric configuration(s)",
-                "=> Cyclomatic Complexity: 10",
-                "=> Cognitive Complexity: 100",
-                "=> Non Commenting Source Statements: <n/a>",
-                "=> N-Path Complexity: <n/a>"
+                "=> Cyclomatic Complexity: 10 (total) [Whole Project]",
+                "=> Cognitive Complexity: 100 (total) [Whole Project]",
+                "=> Non Commenting Source Statements: <n/a> [Whole Project]",
+                "=> N-Path Complexity: <n/a> [Whole Project]"
         );
 
         assertThat(aggregation.getMetrics(Scope.PROJECT)).containsOnly(

--- a/src/test/java/edu/hm/hafner/grading/AnalysisConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisConfigurationTest.java
@@ -1,14 +1,13 @@
 package edu.hm.hafner.grading;
 
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
+import java.util.stream.Stream;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
@@ -114,7 +113,7 @@ class  AnalysisConfigurationTest extends AbstractConfigurationTest {
                       {
                         "id": "checkstyle",
                         "pattern": "target/checkstyle.xml",
-                        "scope": "project"
+                        "scope": "modified_lines"
                       },
                       {
                         "id": "spotbugs",
@@ -132,7 +131,7 @@ class  AnalysisConfigurationTest extends AbstractConfigurationTest {
                 .hasMaxScore(50)
                 .hasName("Checkstyle and SpotBugs")
                 .isPositive().hasImpact()
-                .hasOnlyTools(new ToolConfiguration("checkstyle", "", "target/checkstyle.xml", "", "", "project", ""),
+                .hasOnlyTools(new ToolConfiguration("checkstyle", "", "target/checkstyle.xml", "", "", "modified_lines", ""),
                         new ToolConfiguration("spotbugs", "", "target/spotbugsXml.xml", "", "", "modified_lines", "")));
     }
 

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -176,7 +176,7 @@ class AutoGradingRunnerITest extends ResourceTest {
                     ],
                     "coverage": [
                       {
-                        "name": "JaCoCo",
+                        "name": "JaCoCo Modified Files",
                         "sourcePath": "src/main/java",
                         "tools": [
                           {
@@ -185,7 +185,16 @@ class AutoGradingRunnerITest extends ResourceTest {
                             "pattern": "**/src/**/jacoco.xml",
                             "sourcePath": "src/main/java",
                             "scope": "modified_files"
-                          },
+                          }
+                        ],
+                        "maxScore": 100,
+                        "coveredPercentageImpact": 1,
+                        "missedPercentageImpact": -1
+                      },
+                      {
+                        "name": "JaCoCo Changed Code",
+                        "sourcePath": "src/main/java",
+                        "tools": [
                           {
                             "id": "jacoco",
                             "metric": "branch",
@@ -197,7 +206,7 @@ class AutoGradingRunnerITest extends ResourceTest {
                         "maxScore": 100,
                         "coveredPercentageImpact": 1,
                         "missedPercentageImpact": -1
-                      }
+                    }
                     ]
                   }
             """;
@@ -592,13 +601,13 @@ class AutoGradingRunnerITest extends ResourceTest {
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 1 test configuration(s)",
-                        "-> Unittests (Whole Project) Total: 37",
+                        "-> Unittests Total: 37",
                         "JUnit Score: 65 of 100",
                         "Processing 2 coverage configuration(s)",
-                        "-> Line Coverage (Whole Project) Total: LINE: 10.93% (33/302)",
-                        "-> Branch Coverage (Whole Project) Total: BRANCH: 9.52% (4/42)",
+                        "-> Line Coverage Total: LINE: 10.93% (33/302)",
+                        "-> Branch Coverage Total: BRANCH: 9.52% (4/42)",
                         "=> JaCoCo Score: 20 of 100",
-                        "-> Mutation Coverage (Whole Project) Total: MUTATION: 7.86% (11/140)",
+                        "-> Mutation Coverage Total: MUTATION: 7.86% (11/140)",
                         "=> PIT Score: 16 of 100",
                         "Processing 2 static analysis configuration(s)",
                         "-> CheckStyle (checkstyle): 6 warnings (error: 6)",
@@ -658,20 +667,33 @@ class AutoGradingRunnerITest extends ResourceTest {
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 0 test configuration(s)",
-                        "Processing 1 coverage configuration(s)",
-                        "-> Line Coverage (Modified Files) Total: <none>",
-                        "-> Branch Coverage (Changed Code) Total: <none>",
-                        "=> JaCoCo Score: 100 of 100",
+                        "Processing 2 coverage configuration(s)",
+                        "-> Line Coverage Total: <none> [Modified Files]",
+                        "=> JaCoCo Modified Files Score: 100 of 100 [Modified Files]",
+                        "-> Branch Coverage Total: <none> [Changed Code]",
+                        "=> JaCoCo Changed Code Score: 100 of 100 [Changed Code]",
                         "Processing 2 static analysis configuration(s)",
-                        "-> CheckStyle (checkstyle): No warnings",
-                        "=> Style Score: 0 of 100",
-                        "-> SpotBugs (spotbugs): No warnings",
-                        "=> Bugs Score: 100 of 100",
-                        "Autograding score - 200 of 300 (66%)");
+                        "-> CheckStyle (checkstyle): No warnings [Modified Files]",
+                        "=> Style Score: 0 of 100 [Modified Files]",
+                        "-> SpotBugs (spotbugs): No warnings [Changed Code]",
+                        "=> Bugs Score: 100 of 100 [Changed Code]",
+                        "Autograding score - 300 of 400 (75%)");
 
         var builder = new StringCommentBuilder();
         builder.createAnnotations(score);
         assertThat(builder.getComments()).isEmpty();
+
+        assertThat(score.getMetrics(Scope.PROJECT)).isEmpty();
+        assertThat(score.getMetrics(Scope.MODIFIED_LINES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "branch", 0.0,
+                "bugs", 0.0,
+                "spotbugs", 0.0)
+        );
+        assertThat(score.getMetrics(Scope.MODIFIED_FILES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "line", 0.0,
+                "style", 0.0,
+                "checkstyle", 0.0)
+        );
     }
 
     @Test
@@ -679,7 +701,8 @@ class AutoGradingRunnerITest extends ResourceTest {
     void shouldGradeScopeWithModifiedFiles() {
         var outputStream = new ByteArrayOutputStream();
         var runner = spy(new AutoGradingRunner(createStream(outputStream)));
-        when(runner.getModifiedLines(any())).thenReturn(Map.of("src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(100),
+        when(runner.getModifiedLines(any())).thenReturn(Map.of(
+                "src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(100),
                 "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java", Set.of(0),
                 "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(286)));
 
@@ -688,16 +711,17 @@ class AutoGradingRunnerITest extends ResourceTest {
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 0 test configuration(s)",
-                        "Processing 1 coverage configuration(s)",
-                        "-> Line Coverage (Modified Files) Total: LINE: 10.00% (8/80)",
-                        "-> Branch Coverage (Changed Code) Total: <none>",
-                        "=> JaCoCo Score: 10 of 100",
+                        "Processing 2 coverage configuration(s)",
+                        "-> Line Coverage Total: LINE: 10.00% (8/80) [Modified Files]",
+                        "=> JaCoCo Modified Files Score: 20 of 100 [Modified Files]",
+                        "-> Branch Coverage Total: <none> [Changed Code]",
+                        "=> JaCoCo Changed Code Score: 100 of 100 [Changed Code]",
                         "Processing 2 static analysis configuration(s)",
-                        "-> CheckStyle (checkstyle): 6 warnings (error: 6)",
-                        "=> Style Score: 6 of 100",
-                        "-> SpotBugs (spotbugs): No warnings",
-                        "=> Bugs Score: 100 of 100",
-                        "Autograding score - 116 of 300 (38%)");
+                        "-> CheckStyle (checkstyle): 6 warnings (error: 6) [Modified Files]",
+                        "=> Style Score: 6 of 100 [Modified Files]",
+                        "-> SpotBugs (spotbugs): No warnings [Changed Code]",
+                        "=> Bugs Score: 100 of 100 [Changed Code]",
+                        "Autograding score - 226 of 400 (56%)");
 
         var builder = new StringCommentBuilder();
         builder.createAnnotations(score);
@@ -712,6 +736,18 @@ class AutoGradingRunnerITest extends ResourceTest {
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:152-153: Lines 152-153 are not covered by tests (Not covered lines)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:160-160: Line 160 is not covered by tests (Not covered line)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:164-166: Lines 164-166 are not covered by tests (Not covered lines)");
+
+        assertThat(score.getMetrics(Scope.PROJECT)).isEmpty();
+        assertThat(score.getMetrics(Scope.MODIFIED_LINES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "branch", 0.0,
+                "bugs", 0.0,
+                "spotbugs", 0.0)
+        );
+        assertThat(score.getMetrics(Scope.MODIFIED_FILES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "checkstyle", 6.0,
+                "line", 10.0,
+                "style", 6.0)
+        );
     }
 
     @Test
@@ -721,22 +757,25 @@ class AutoGradingRunnerITest extends ResourceTest {
         var runner = spy(new AutoGradingRunner(createStream(outputStream)));
         when(runner.getModifiedLines(any())).thenReturn(Map.of("src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(42, 146),
                 "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java", Set.of(17),
-                "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(0)));
+                "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(0),
+                "edu/hm/hafner/analysis/IssuesTest.java", Set.of(286)));
 
         var score = runner.run();
 
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 0 test configuration(s)",
-                        "Processing 1 coverage configuration(s)",
-                        "-> Line Coverage (Modified Files) Total: LINE: 10.00% (8/80)",
-                        "-> Branch Coverage (Changed Code) Total: BRANCH: 50.00% (1/2)",
-                        "=> JaCoCo Score: 60 of 100",
+                        "Processing 2 coverage configuration(s)",
+                        "-> Line Coverage Total: LINE: 10.00% (8/80) [Modified Files]",
+                        "=> JaCoCo Modified Files Score: 20 of 100 [Modified Files]",
+                        "-> Branch Coverage Total: BRANCH: 50.00% (1/2) [Changed Code]",
+                        "=> JaCoCo Changed Code Score: 100 of 100 [Changed Code]",
                         "Processing 2 static analysis configuration(s)",
-                        "-> CheckStyle (checkstyle): 6 warnings (error: 6)",
-                        "=> Style Score: 6 of 100",
-                        "-> SpotBugs (spotbugs): No warnings",
-                        "Autograding score - 166 of 300 (55%)");
+                        "-> CheckStyle (checkstyle): 6 warnings (error: 6) [Modified Files]",
+                        "=> Style Score: 6 of 100 [Modified Files]",
+                        "-> SpotBugs (spotbugs): 1 warning (low: 1) [Changed Code]",
+                        "=> Bugs Score: 86 of 100 [Changed Code]",
+                        "Autograding score - 212 of 400 (53%)");
 
         var builder = new StringCommentBuilder();
         builder.createAnnotations(score);
@@ -746,11 +785,24 @@ class AutoGradingRunnerITest extends ResourceTest {
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:29-29: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:30-30: '}' sollte in derselben Zeile stehen. (CheckStyle: RightCurlyCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:37-37: '}' sollte in derselben Zeile stehen. (CheckStyle: RightCurlyCheck)",
+                "[WARNING] edu/hm/hafner/analysis/IssuesTest.java:286-286: Return value of Issues.get(int) ignored, but method has no side effect (SpotBugs: RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:41-140: Lines 41-140 are not covered by tests (Not covered lines)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:152-153: Lines 152-153 are not covered by tests (Not covered lines)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:160-160: Line 160 is not covered by tests (Not covered line)",
                 "[NO_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:164-166: Lines 164-166 are not covered by tests (Not covered lines)",
                 "[PARTIAL_COVERAGE] edu/hm/hafner/grading/AutoGradingAction.java:146-146: Line 146 is only partially covered, one branch is missing (Partially covered line)");
+
+        assertThat(score.getMetrics(Scope.PROJECT)).isEmpty();
+        assertThat(score.getMetrics(Scope.MODIFIED_LINES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "branch", 50.0,
+                "bugs", 1.0,
+                "spotbugs", 1.0)
+        );
+        assertThat(score.getMetrics(Scope.MODIFIED_FILES)).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "checkstyle", 6.0,
+                "line", 10.0,
+                "style", 6.0)
+        );
     }
 
     private PrintStream createStream(final ByteArrayOutputStream outputStream) {
@@ -766,9 +818,9 @@ class AutoGradingRunnerITest extends ResourceTest {
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 1 coverage configuration(s)",
-                        "-> Line Coverage (Whole Project) Total: LINE: 100.00% (2/2)",
-                        "-> Branch Coverage (Whole Project) Total: <none>",
-                        "=> JaCoCo Score: 100 of 100",
+                        "-> Line Coverage Total: LINE: 100.00% (2/2) [Whole Project]",
+                        "-> Branch Coverage Total: <none> [Whole Project]",
+                        "=> JaCoCo Score: 100 of 100 [Whole Project]",
                         "Autograding score - 100 of 100");
     }
 
@@ -783,21 +835,21 @@ class AutoGradingRunnerITest extends ResourceTest {
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains(
                         "Searching for Cyclomatic Complexity results matching file name pattern **/src/**/metrics-exception.xml",
-                        "Cyclomatic Complexity (Whole Project) Total: <none>",
-                        "=> Cyclomatic Complexity: <n/a>",
-                        "-> Cognitive Complexity (Whole Project) Total: <none>",
-                        "=> Cognitive Complexity: <n/a>",
-                        "-> N-Path Complexity (Whole Project) Total: <none>",
-                        "=> N-Path Complexity: <n/a>",
-                        "-> Lines of Code (Whole Project) Total: 10",
-                        "=> Lines of Code: 10 (total)",
-                        "-> Non Commenting Source Statements (Whole Project) Total: 2",
-                        "=> Non Commenting Source Statements: 2 (total)",
-                        "-> Class Cohesion (Whole Project) Total: 0",
-                        "=> Class Cohesion: 0.00% (maximum)",
-                        "-> Weight of Class (Whole Project) Total: 0",
-                        "=> Weight of Class: 0.00% (maximum)",
-                        "=> Software Metrics: <n/a>");
+                        "Cyclomatic Complexity Total: <none> [Whole Project]",
+                        "=> Cyclomatic Complexity: <n/a> [Whole Project]",
+                        "-> Cognitive Complexity Total: <none> [Whole Project]",
+                        "=> Cognitive Complexity: <n/a> [Whole Project]",
+                        "-> N-Path Complexity Total: <none> [Whole Project]",
+                        "=> N-Path Complexity: <n/a> [Whole Project]",
+                        "-> Lines of Code Total: 10 [Whole Project]",
+                        "=> Lines of Code: 10 (total) [Whole Project]",
+                        "-> Non Commenting Source Statements Total: 2 [Whole Project]",
+                        "=> Non Commenting Source Statements: 2 (total) [Whole Project]",
+                        "-> Class Cohesion Total: 0.00% [Whole Project]",
+                        "=> Class Cohesion: 0.00% (maximum) [Whole Project]",
+                        "-> Weight of Class Total: 0.00% [Whole Project]",
+                        "=> Weight of Class: 0.00% (maximum) [Whole Project]",
+                        "=> Software Metrics: <n/a> [Whole Project]");
 
         var c = ArgumentCaptor.forClass(AggregatedScore.class);
         verify(runner).publishGradingResult(c.capture(), any(), any());
@@ -822,7 +874,7 @@ class AutoGradingRunnerITest extends ResourceTest {
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
                 .contains("Processing 1 test configuration(s)",
-                        "-> Modultests (Whole Project) Total: 23",
+                        "-> Modultests Total: 23",
                         "=> Modultests Score: 100 of 100",
                         "Autograding score - 100 of 100");
     }

--- a/src/test/java/edu/hm/hafner/grading/CoverageConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageConfigurationTest.java
@@ -195,7 +195,7 @@ class CoverageConfigurationTest extends AbstractConfigurationTest {
                         "icon": "jacoco.png",
                         "pattern": "target/jacoco.xml",
                         "metric": "line",
-                        "scope": "project"
+                        "scope": "modified_files"
                       },
                       {
                         "id": "pit",
@@ -230,7 +230,7 @@ class CoverageConfigurationTest extends AbstractConfigurationTest {
                         "pattern": "target/jacoco.xml",
                         "icon": "jacoco.png",
                         "metric": "line",
-                        "scope": "project"
+                        "scope": "modified_files"
                       },
                       {
                         "id": "pit",
@@ -276,7 +276,7 @@ class CoverageConfigurationTest extends AbstractConfigurationTest {
                 .hasImpact()
                 .hasOnlyTools(
                         new ToolConfiguration("jacoco", "JaCoCo", "target/jacoco.xml",
-                                getMetricName(Metric.LINE), "jacoco.png", "project", ""),
+                                getMetricName(Metric.LINE), "jacoco.png", "modified_files", ""),
                         new ToolConfiguration("pit", "PITest", "target/mutations.xml",
                                 getMetricName(Metric.MUTATION), "pit.png", "modified_files", ""));
     }

--- a/src/test/java/edu/hm/hafner/grading/FileSystemToolParserTest.java
+++ b/src/test/java/edu/hm/hafner/grading/FileSystemToolParserTest.java
@@ -135,8 +135,8 @@ class FileSystemToolParserTest {
         assertFileNodes(node.getAllFileNodes());
         assertThat(log.getInfoMessages()).containsExactly(
                 "Searching for Line Coverage results matching file name pattern **/src/**/jacoco.xml",
-                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302)",
-                "-> Line Coverage (Whole Project) Total: LINE: 10.93% (33/302)");
+                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302) [Whole Project]",
+                "-> Line Coverage Total: LINE: 10.93% (33/302) [Whole Project]");
     }
 
     @Test
@@ -149,16 +149,16 @@ class FileSystemToolParserTest {
         assertFileNodes(score.getCoveredFiles(Metric.LINE));
         assertThat(log.getInfoMessages()).contains(
                 "Searching for Line Coverage results matching file name pattern **/src/**/jacoco.xml",
-                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302)",
-                "-> Line Coverage (Whole Project) Total: LINE: 10.93% (33/302)",
+                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302) [Whole Project]",
+                "-> Line Coverage Total: LINE: 10.93% (33/302) [Whole Project]",
                 "Searching for Branch Coverage results matching file name pattern **/src/**/jacoco.xml",
-                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: BRANCH: 9.52% (4/42)",
-                "-> Branch Coverage (Whole Project) Total: BRANCH: 9.52% (4/42)",
-                "=> JaCoCo Score: 20 of 100",
+                "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: BRANCH: 9.52% (4/42) [Whole Project]",
+                "-> Branch Coverage Total: BRANCH: 9.52% (4/42) [Whole Project]",
+                "=> JaCoCo Score: 20 of 100 [Whole Project]",
                 "Searching for Mutation Coverage results matching file name pattern **/src/**/mutations.xml",
-                "- src/test/resources/edu/hm/hafner/grading/mutations.xml: MUTATION: 7.86% (11/140)",
-                "-> Mutation Coverage (Whole Project) Total: MUTATION: 7.86% (11/140)",
-                "=> PIT Score: 16 of 100");
+                "- src/test/resources/edu/hm/hafner/grading/mutations.xml: MUTATION: 7.86% (11/140) [Whole Project]",
+                "-> Mutation Coverage Total: MUTATION: 7.86% (11/140) [Whole Project]",
+                "=> PIT Score: 16 of 100 [Whole Project]");
 
         assertThat(score.getCoveredFiles(Metric.LINE)
                 .stream()
@@ -214,19 +214,19 @@ class FileSystemToolParserTest {
                 .hasSize(6).containsOnly("CheckStyle");
         assertThat(log.getInfoMessages()).contains(
                 "Searching for CheckStyle results matching file name pattern **/src/**/checkstyle*.xml",
-                "- src/test/resources/edu/hm/hafner/grading/checkstyle.xml: 6 warnings",
-                "-> CheckStyle (checkstyle): 6 warnings (error: 6)",
+                "- src/test/resources/edu/hm/hafner/grading/checkstyle.xml: 6 warnings [Whole Project]",
+                "-> CheckStyle (checkstyle): 6 warnings (error: 6) [Whole Project]",
                 "Searching for PMD results matching file name pattern **/src/**/pmd*.xml",
-                "- src/test/resources/edu/hm/hafner/grading/pmd.xml: 4 warnings",
-                "-> PMD (pmd): 4 warnings (high: 1, normal: 2, low: 1)",
-                "=> Style Score: 18 of 100",
+                "- src/test/resources/edu/hm/hafner/grading/pmd.xml: 4 warnings [Whole Project]",
+                "-> PMD (pmd): 4 warnings (high: 1, normal: 2, low: 1) [Whole Project]",
+                "=> Style Score: 18 of 100 [Whole Project]",
                 "Searching for SpotBugs results matching file name pattern **/src/**/spotbugs*.xml",
-                "- src/test/resources/edu/hm/hafner/grading/spotbugsXml.xml: 2 bugs",
-                "-> SpotBugs (spotbugs): 2 bugs (low: 2)",
+                "- src/test/resources/edu/hm/hafner/grading/spotbugsXml.xml: 2 bugs [Whole Project]",
+                "-> SpotBugs (spotbugs): 2 bugs (low: 2) [Whole Project]",
                 "Searching for Error Prone results matching file name pattern **/src/**/error-prone.log",
-                "- src/test/resources/edu/hm/hafner/grading/error-prone.log: 1 bug",
-                "-> Error Prone (error-prone): 1 bug (normal: 1)",
-                "=> Bugs Score: 59 of 100");
+                "- src/test/resources/edu/hm/hafner/grading/error-prone.log: 1 bug [Whole Project]",
+                "-> Error Prone (error-prone): 1 bug (normal: 1) [Whole Project]",
+                "=> Bugs Score: 59 of 100 [Whole Project]");
 
         var gradingReport = new GradingReport();
         assertThat(gradingReport.getMarkdownSummary(score)).contains(

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -220,23 +220,23 @@ class GradingReportTest {
                 AnalysisConfiguration.from(configuration));
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 2 static analysis configuration(s)",
-                "=> Style: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                "=> Bugs: 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                "=> Style: 10 warnings (error: 1, high: 2, normal: 3, low: 4) [Whole Project]",
+                "=> Bugs: 10 bugs (error: 4, high: 3, normal: 2, low: 1) [Whole Project]");
 
         aggregation.gradeTests(
                 new NodeSupplier(TestMarkdownTest::createTwoReports),
                 TestConfiguration.from(configuration));
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 1 test configuration(s)",
-                "=> JUnit: 26.32% successful (14 failed, 5 passed, 3 skipped)");
+                "=> JUnit: 26.32% successful (14 failed, 5 passed, 3 skipped) [Whole Project]");
 
         aggregation.gradeCoverage(
                 new NodeSupplier(CoverageMarkdownTest::createTwoReports),
                 CoverageConfiguration.from(configuration));
         assertThat(String.join("\n", logger.getInfoMessages())).contains(
                 "Processing 2 coverage configuration(s)",
-                "=> JaCoCo: 70.00% (60 missed items)",
-                "=> PIT: 60.00% (40 survived mutations)"
+                "=> JaCoCo: 70.00% (60 missed items) [Whole Project]",
+                "=> PIT: 60.00% (40 survived mutations) [Whole Project]"
         );
 
         assertThat(aggregation.getMetrics(Scope.PROJECT)).containsOnly(

--- a/src/test/java/edu/hm/hafner/grading/ScopeTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ScopeTest.java
@@ -20,14 +20,14 @@ class ScopeTest {
     }
 
     @ParameterizedTest(name = "value={0}")
-    @ValueSource(strings = {"modified-files", "MODIFIED_FILES", "files", "Files"})
+    @ValueSource(strings = {"modified-files", "MODIFIED_FILES", "changed", "files", "Files"})
     @DisplayName("Convert String value to Modified Files Scope")
     void shouldReturnFilesScope(final String value) {
         assertThat(Scope.fromString(value)).isEqualTo(Scope.MODIFIED_FILES);
     }
 
     @ParameterizedTest(name = "value={0}")
-    @ValueSource(strings = {"modified-lines", "MODIFIED_LINES", "lines", "Lines"})
+    @ValueSource(strings = {"modified-lines", "MODIFIED_LINES", "lines", "Lines", "code", "new"})
     @DisplayName("Convert String value to Modified Lines Scope")
     void shouldReturnCodeScope(final String value) {
         assertThat(Scope.fromString(value)).isEqualTo(Scope.MODIFIED_LINES);

--- a/src/test/java/edu/hm/hafner/grading/TestConfigurationTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestConfigurationTest.java
@@ -280,7 +280,7 @@ class TestConfigurationTest extends AbstractConfigurationTest {
                         "name": "Junit tests",
                         "pattern": "target/junit.xml",
                         "icon": "junit.png",
-                        "scope": "project"
+                        "scope": "modified_files"
                       },
                       {
                         "id": "jest",
@@ -313,7 +313,7 @@ class TestConfigurationTest extends AbstractConfigurationTest {
                         "pattern": "target/junit.xml",
                         "name": "Junit tests",
                         "icon": "junit.png",
-                        "scope": "project"
+                        "scope": "modified_files"
                       },
                       {
                         "id": "jest",
@@ -357,7 +357,7 @@ class TestConfigurationTest extends AbstractConfigurationTest {
                 .isPositive()
                 .isAbsolute()
                 .isNotRelative()
-                .hasOnlyTools(new ToolConfiguration("junit", "Junit tests", "target/junit.xml", "", "junit.png", "project", ""),
+                .hasOnlyTools(new ToolConfiguration("junit", "Junit tests", "target/junit.xml", "", "junit.png", "modified_files", ""),
                         new ToolConfiguration("jest", "JEST", "target/jest.xml", "", "", "modified_files", ""));
     }
 


### PR DESCRIPTION
When creating the scores, the scope has been forgotten in analysis scopes.