### PR TITLE
Improve logging so we see the whole project and the scope values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <jackson-databind.version>2.20.1</jackson-databind.version>
     <analysis-model.version>13.18.0</analysis-model.version>
-    <coverage-model.version>0.64.1</coverage-model.version>
+    <coverage-model.version>0.65.0</coverage-model.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -1,17 +1,22 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.grading.QualityGateResult.OverallStatus;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.SecureXmlParserFactory;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * GitHub action entrypoint for the autograding action.
@@ -81,8 +86,10 @@ public class AutoGradingRunner {
         logHandler.print();
 
         try {
+            var modifiedLines = obtainModifiedLines(log);
+
             log.logInfo(DOUBLE_LINE);
-            var parserFacade = new FileSystemToolParser(getModifiedLines(log));
+            var parserFacade = new FileSystemToolParser(modifiedLines);
             score.gradeTests(parserFacade, TestConfiguration.from(configuration));
             logHandler.print();
 
@@ -141,6 +148,20 @@ public class AutoGradingRunner {
         }
 
         return score;
+    }
+
+    private Map<String, Set<Integer>> obtainModifiedLines(final FilteredLog log) {
+        log.logInfo(DOUBLE_LINE);
+        var modifiedLines = getModifiedLines(log);
+        if (modifiedLines.isEmpty()) {
+            log.logInfo("No modified lines information available");
+        }
+        else {
+            log.logInfo("Modified lines information for %d files available", modifiedLines.size());
+            modifiedLines.forEach((file, lines) ->
+                    log.logInfo("- %s: %s", file, lines));
+        }
+        return modifiedLines;
     }
 
     private List<QualityGate> readQualityGatesFromEnvVariable(final FilteredLog log) {

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -77,7 +77,7 @@ public final class FileSystemToolParser implements ToolParser {
                 total.addAll(report.getInModifiedCode());
             }
 
-            log.logInfo("- %s: %s [%s]", PATH_UTIL.getRelativePath(file), report.getSummary(), scope.getDisplayName());
+            log.logInfo("- %s: %s [Whole Project]", PATH_UTIL.getRelativePath(file), report.getSummary());
         }
 
         log.logInfo("-> %s [%s]", total.toString(), scope.getDisplayName());
@@ -103,13 +103,17 @@ public final class FileSystemToolParser implements ToolParser {
                     }
                 }
 
+                log.logInfo("- %s: %s [Whole Project]", PATH_UTIL.getRelativePath(file), extractMetric(tool, node));
+
                 Node result = switch (scope) {
                     case MODIFIED_FILES -> node.filterByModifiedFiles();
                     case MODIFIED_LINES -> node.filterByModifiedLines();
                     default -> node;
                 };
 
-                log.logInfo("- %s: %s [%s]", PATH_UTIL.getRelativePath(file), extractMetric(tool, result), scope.getDisplayName());
+                if (scope != Scope.PROJECT) {
+                    log.logInfo("- %s: %s [%s]", PATH_UTIL.getRelativePath(file), extractMetric(tool, result), scope.getDisplayName());
+                }
                 nodes.add(result);
             }
             catch (IOException exception) {

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -665,16 +665,23 @@ class AutoGradingRunnerITest extends ResourceTest {
         var score = runner.run();
 
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
-                .contains("Obtaining configuration from environment variable CONFIG")
-                .contains("Processing 0 test configuration(s)",
+                .contains("Obtaining configuration from environment variable CONFIG",
+                        "No modified lines information available",
+                        "Processing 0 test configuration(s)",
                         "Processing 2 coverage configuration(s)",
+                        "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302) [Whole Project]",
+                        "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: <none> [Modified Files]",
                         "-> Line Coverage Total: <none> [Modified Files]",
                         "=> JaCoCo Modified Files Score: 100 of 100 [Modified Files]",
+                        "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: BRANCH: 9.52% (4/42) [Whole Project]",
+                        "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: <none> [Changed Code]",
                         "-> Branch Coverage Total: <none> [Changed Code]",
                         "=> JaCoCo Changed Code Score: 100 of 100 [Changed Code]",
                         "Processing 2 static analysis configuration(s)",
+                        "- src/test/resources/edu/hm/hafner/grading/checkstyle.xml: 6 warnings [Whole Project]",
                         "-> CheckStyle (checkstyle): No warnings [Modified Files]",
                         "=> Style Score: 0 of 100 [Modified Files]",
+                        "- src/test/resources/edu/hm/hafner/grading/spotbugsXml.xml: 2 bugs [Whole Project]",
                         "-> SpotBugs (spotbugs): No warnings [Changed Code]",
                         "=> Bugs Score: 100 of 100 [Changed Code]",
                         "Autograding score - 300 of 400 (75%)");
@@ -703,14 +710,19 @@ class AutoGradingRunnerITest extends ResourceTest {
         var runner = spy(new AutoGradingRunner(createStream(outputStream)));
         when(runner.getModifiedLines(any())).thenReturn(Map.of(
                 "src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(100),
-                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java", Set.of(0),
+                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java",
+                Set.of(0),
                 "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(286)));
 
         var score = runner.run();
 
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
-                .contains("Obtaining configuration from environment variable CONFIG")
-                .contains("Processing 0 test configuration(s)",
+                .contains("Obtaining configuration from environment variable CONFIG",
+                        "Modified lines information for 3 files available",
+                        "- src/main/java/edu/hm/hafner/analysis/IssuesTest.java: [286]",
+                        "- X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java: [0]",
+                        "- src/main/java/edu/hm/hafner/grading/AutoGradingAction.java: [100]",
+                        "Processing 0 test configuration(s)",
                         "Processing 2 coverage configuration(s)",
                         "-> Line Coverage Total: LINE: 10.00% (8/80) [Modified Files]",
                         "=> JaCoCo Modified Files Score: 20 of 100 [Modified Files]",
@@ -755,16 +767,23 @@ class AutoGradingRunnerITest extends ResourceTest {
     void shouldGradeScopeWithModifiedLines() {
         var outputStream = new ByteArrayOutputStream();
         var runner = spy(new AutoGradingRunner(createStream(outputStream)));
-        when(runner.getModifiedLines(any())).thenReturn(Map.of("src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(42, 146),
-                "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java", Set.of(17),
-                "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(0),
-                "edu/hm/hafner/analysis/IssuesTest.java", Set.of(286)));
+        when(runner.getModifiedLines(any())).thenReturn(
+                Map.of("src/main/java/edu/hm/hafner/grading/AutoGradingAction.java", Set.of(42, 146),
+                        "X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java",
+                        Set.of(17),
+                        "src/main/java/edu/hm/hafner/analysis/IssuesTest.java", Set.of(0),
+                        "edu/hm/hafner/analysis/IssuesTest.java", Set.of(286)));
 
         var score = runner.run();
 
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
-                .contains("Obtaining configuration from environment variable CONFIG")
-                .contains("Processing 0 test configuration(s)",
+                .contains("Obtaining configuration from environment variable CONFIG",
+                        "Modified lines information for 4 files available",
+                        "- src/main/java/edu/hm/hafner/analysis/IssuesTest.java: [0]",
+                        "- src/main/java/edu/hm/hafner/grading/AutoGradingAction.java: [42, 146]",
+                        "- edu/hm/hafner/analysis/IssuesTest.java: [286]",
+                        "- X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java: [17]",
+                        "Processing 0 test configuration(s)",
                         "Processing 2 coverage configuration(s)",
                         "-> Line Coverage Total: LINE: 10.00% (8/80) [Modified Files]",
                         "=> JaCoCo Modified Files Score: 20 of 100 [Modified Files]",
@@ -779,7 +798,8 @@ class AutoGradingRunnerITest extends ResourceTest {
 
         var builder = new StringCommentBuilder();
         builder.createAnnotations(score);
-        assertThat(builder.getComments()).containsExactly("[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:17-17: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
+        assertThat(builder.getComments()).containsExactly(
+                "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:17-17: Die Methode 'accepts' ist nicht für Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:42-42: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:22-22: Die Methode 'detectPackageName' ist nicht fr Vererbung entworfen - muss abstract, final oder leer sein. (CheckStyle: DesignForExtensionCheck)",
                 "[WARNING] X:/Build/Results/jobs/Maven/workspace/tasks/src/main/java/hudson/plugins/tasks/parser/CsharpNamespaceDetector.java:29-29: Zeile länger als 80 Zeichen (CheckStyle: LineLengthCheck)",


### PR DESCRIPTION
The logging statements should show the values for the whole project and the filtered elements. When filtering has been applied, show the affected lines and files.