### PR TITLE
Use only width when rendering `<img>` tags

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisMarkdown.java
@@ -94,8 +94,8 @@ public class AnalysisMarkdown extends ScoreMarkdown<AnalysisScore, AnalysisConfi
         if (REGISTRY.contains(parserId)) {
             var descriptor = REGISTRY.get(parserId);
             if (!descriptor.getIconUrl().isBlank()) {
-                return format("<img src=\"%s\" alt=\"%s\" height=\"%d\" width=\"%d\">",
-                        descriptor.getIconUrl(), score.getName(), ICON_SIZE, ICON_SIZE);
+                return format("<img src=\"%s\" alt=\"%s\" width=\"%d\">",
+                        descriptor.getIconUrl(), score.getName(), ICON_SIZE);
             }
         }
         return getDefaultIcon(score);

--- a/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreMarkdown.java
@@ -52,9 +52,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     private final String icon;
 
     static String iconUrl(final String url, final String altText) {
-        return format(
-                "<img src=\"%s\" alt=\"%s\" height=\"%d\" width=\"%d\">",
-                url, altText, ICON_SIZE, ICON_SIZE);
+        return format("<img src=\"%s\" alt=\"%s\" width=\"%d\">", url, altText, ICON_SIZE);
     }
 
     ScoreMarkdown(final String type, final String icon) {
@@ -297,7 +295,7 @@ abstract class ScoreMarkdown<S extends Score<S, C>, C extends Configuration> {
     static String openmoji(final String configurationIcon, final String label) {
         var icon = Strings.CS.removeStart(configurationIcon, OPEN_MOJI);
         return ("<img src=\"https://openmoji.org/data/color/svg/"
-                + "%s.svg\" alt=\"%s\" height=\"18\" width=\"18\">").formatted(icon, label);
+                + "%s.svg\" alt=\"%s\" width=\"18\">").formatted(icon, label);
     }
 
     String formatColumns(final Object... columns) {

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -66,7 +66,9 @@ class AnalysisMarkdownTest {
                 .contains("Static Analysis Warnings - 100 of 100")
                 .contains("|CheckStyle|Whole Project|0|0|:white_check_mark:");
         assertThat(analysisMarkdown.createSummary(score))
-                .contains("CheckStyle (Whole Project) - 100 of 100", "checkstyle_logo_small_64.png", "No warnings");
+                .contains("CheckStyle (Whole Project) - 100 of 100", "No warnings")
+                .contains("<img", "width=", "checkstyle_logo_small_64.png")
+                .doesNotContain("height=");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -72,7 +72,9 @@ class TestMarkdownTest {
         var testMarkdown = new TestMarkdown();
 
         assertThat(clean(testMarkdown.createSummary(score)))
-                .contains("JUnit (Whole Project):", "✅", "999999 passed");
+                .contains("JUnit (Whole Project):", "✅", "999999 passed")
+                .contains("<img", "width=", "junit-diamond.svg")
+                .doesNotContain("height=");
 
         classNode.addTestCase(builder.withTestName("Failed Test").withFailure().build());
         root.replaceValue(new Rate(Metric.TEST_SUCCESS_RATE, 999_999, 1_000_000));


### PR DESCRIPTION
Using width and height seems broken in GitHub now.

Example: https://github.com/uhafner/codingstyle/pull/1838#issuecomment-4294422846