### PR TITLE
Ensure that reference results are skipped when parsing PR reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>autograding-model</artifactId>
-  <version>16.2.0-SNAPSHOT</version>
+  <version>17.0.0-SNAPSHOT</version>
   <name>Autograding Model</name>
 
   <description>This module autogrades Java projects based on a configurable set of metrics.</description>

--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -335,7 +335,7 @@ public final class AggregatedScore implements Serializable {
      * @param deltaReports
      *         the optional file path to the delta reports
      */
-    public void gradeAnalysis(final ToolParser factory,
+    void gradeAnalysis(final ToolParser factory,
             final List<AnalysisConfiguration> analysisConfigurations, final String deltaReports) {
         grade(factory, analysisConfigurations, new AnalysisScoreBuilder(deltaReports), analysisScores::add);
     }
@@ -350,7 +350,7 @@ public final class AggregatedScore implements Serializable {
      * @param deltaReports
      *         the optional file path to the delta reports
      */
-    public void gradeCoverage(final ToolParser factory,
+    void gradeCoverage(final ToolParser factory,
             final List<CoverageConfiguration> coverageConfigurations, final String deltaReports) {
         grade(factory, coverageConfigurations, new CoverageScoreBuilder(deltaReports), coverageScores::add);
     }
@@ -365,7 +365,7 @@ public final class AggregatedScore implements Serializable {
      * @param deltaReports
      *         the optional file path to the delta reports
      */
-    public void gradeTests(final ToolParser factory,
+    void gradeTests(final ToolParser factory,
                            final List<TestConfiguration> testConfigurations, final String deltaReports) {
         grade(factory, testConfigurations, new TestScoreBuilder(deltaReports), testScores::add);
     }
@@ -380,7 +380,7 @@ public final class AggregatedScore implements Serializable {
      * @param deltaReports
      *         the optional file path to the delta reports
      */
-    public void gradeMetrics(final ToolParser factory,
+    void gradeMetrics(final ToolParser factory,
                              final List<MetricConfiguration> metricConfigurations, final String deltaReports) {
         grade(factory, metricConfigurations, new MetricScoreBuilder(deltaReports), metricScores::add);
     }

--- a/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AggregatedScore.java
@@ -18,14 +18,12 @@ import edu.hm.hafner.util.Generated;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -338,7 +336,7 @@ public final class AggregatedScore implements Serializable {
      *         the optional file path to the delta reports
      */
     public void gradeAnalysis(final ToolParser factory,
-            final List<AnalysisConfiguration> analysisConfigurations, final Optional<Path> deltaReports) {
+            final List<AnalysisConfiguration> analysisConfigurations, final String deltaReports) {
         grade(factory, analysisConfigurations, new AnalysisScoreBuilder(deltaReports), analysisScores::add);
     }
 
@@ -353,7 +351,7 @@ public final class AggregatedScore implements Serializable {
      *         the optional file path to the delta reports
      */
     public void gradeCoverage(final ToolParser factory,
-            final List<CoverageConfiguration> coverageConfigurations, final Optional<Path> deltaReports) {
+            final List<CoverageConfiguration> coverageConfigurations, final String deltaReports) {
         grade(factory, coverageConfigurations, new CoverageScoreBuilder(deltaReports), coverageScores::add);
     }
 
@@ -368,7 +366,7 @@ public final class AggregatedScore implements Serializable {
      *         the optional file path to the delta reports
      */
     public void gradeTests(final ToolParser factory,
-                           final List<TestConfiguration> testConfigurations, final Optional<Path> deltaReports) {
+                           final List<TestConfiguration> testConfigurations, final String deltaReports) {
         grade(factory, testConfigurations, new TestScoreBuilder(deltaReports), testScores::add);
     }
 
@@ -383,7 +381,7 @@ public final class AggregatedScore implements Serializable {
      *         the optional file path to the delta reports
      */
     public void gradeMetrics(final ToolParser factory,
-                             final List<MetricConfiguration> metricConfigurations, final Optional<Path> deltaReports) {
+                             final List<MetricConfiguration> metricConfigurations, final String deltaReports) {
         grade(factory, metricConfigurations, new MetricScoreBuilder(deltaReports), metricScores::add);
     }
 

--- a/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisScore.java
@@ -13,10 +13,8 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.Generated;
 
 import java.io.Serial;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static edu.hm.hafner.analysis.Severity.*;
@@ -243,11 +241,11 @@ public final class AnalysisScore extends Score<AnalysisScore, AnalysisConfigurat
      */
     static class AnalysisScoreBuilder extends ScoreBuilder<AnalysisScore, AnalysisConfiguration> {
         AnalysisScoreBuilder() {
-            this(Optional.empty());
+            this(NO_DELTA_REPORTS);
         }
 
-        AnalysisScoreBuilder(final Optional<Path> deltaReports) {
-            super(deltaReports);
+        AnalysisScoreBuilder(final String deltaReportsPath) {
+            super(deltaReportsPath);
         }
 
         @Override

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingRunner.java
@@ -32,6 +32,7 @@ public abstract class AutoGradingRunner {
     private static final int ERROR_CAPACITY = 1024;
     private static final String LOG_CONTAINS_ERRORS = "Autograding finished with some errors in the log, failing the action";
     private static final String QUALITY_GATES_FAILED = "Quality gates failed, failing the action";
+    private static final String DEFAULT_WORKSPACE = ".";
 
     private final PrintStream outputStream;
     private Map<String, Set<Integer>> modifiedFilesAndLines = Map.of();
@@ -121,24 +122,24 @@ public abstract class AutoGradingRunner {
     private void grade(final AggregatedScore score, final String configuration, final FilteredLog log,
             final LogHandler logHandler) {
         var parserFacade = new FileSystemToolParser(modifiedFilesAndLines);
-        var deltaReports = fetchDeltaReportsFromPreviousPipeline(log);
+        String deltaPath = fetchDeltaReportsFromPreviousPipeline(log).map(Path::toString).orElse(DEFAULT_WORKSPACE);
 
-        score.gradeTests(parserFacade, TestConfiguration.from(configuration), deltaReports);
+        score.gradeTests(parserFacade, TestConfiguration.from(configuration), deltaPath);
         logHandler.print();
 
         log.logInfo(DOUBLE_LINE);
 
-        score.gradeCoverage(parserFacade, CoverageConfiguration.from(configuration), deltaReports);
+        score.gradeCoverage(parserFacade, CoverageConfiguration.from(configuration), deltaPath);
         logHandler.print();
 
         log.logInfo(DOUBLE_LINE);
 
-        score.gradeAnalysis(parserFacade, AnalysisConfiguration.from(configuration), deltaReports);
+        score.gradeAnalysis(parserFacade, AnalysisConfiguration.from(configuration), deltaPath);
         logHandler.print();
 
         log.logInfo(DOUBLE_LINE);
 
-        score.gradeMetrics(parserFacade, MetricConfiguration.from(configuration), deltaReports);
+        score.gradeMetrics(parserFacade, MetricConfiguration.from(configuration), deltaPath);
         logHandler.print();
 
         log.logInfo(DOUBLE_LINE);

--- a/src/main/java/edu/hm/hafner/grading/CoverageScore.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageScore.java
@@ -13,10 +13,8 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.Generated;
 
 import java.io.Serial;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -252,11 +250,11 @@ public final class CoverageScore extends Score<CoverageScore, CoverageConfigurat
      */
     static class CoverageScoreBuilder extends ScoreBuilder<CoverageScore, CoverageConfiguration> {
         CoverageScoreBuilder() {
-            this(Optional.empty());
+            this(NO_DELTA_REPORTS);
         }
 
-        CoverageScoreBuilder(final Optional<Path> deltaReports) {
-            super(deltaReports);
+        CoverageScoreBuilder(final String deltaReportsPath) {
+            super(deltaReportsPath);
         }
 
         @Override

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -30,7 +30,7 @@ import java.util.Set;
  * @author Ullrich Hafner
  * @author Jannik Ohme
  */
-public final class FileSystemToolParser implements ToolParser {
+final class FileSystemToolParser implements ToolParser {
     private static final ReportFinder REPORT_FINDER = new ReportFinder();
     private static final PathUtil PATH_UTIL = new PathUtil();
 
@@ -39,7 +39,7 @@ public final class FileSystemToolParser implements ToolParser {
     /**
      * Creates a new parser without information about modified lines in files.
      */
-    public FileSystemToolParser() {
+    FileSystemToolParser() {
         this(Map.of());
     }
 
@@ -49,7 +49,7 @@ public final class FileSystemToolParser implements ToolParser {
      * @param modifiedLines
      *         the map of changed file paths to their changed lines
      */
-    public FileSystemToolParser(final Map<String, Set<Integer>> modifiedLines) {
+    FileSystemToolParser(final Map<String, Set<Integer>> modifiedLines) {
         this.modifiedLines = modifiedLines;
     }
 

--- a/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/FileSystemToolParser.java
@@ -54,7 +54,8 @@ public final class FileSystemToolParser implements ToolParser {
     }
 
     @Override
-    public Report readReport(final ToolConfiguration tool, final String directory, final FilteredLog log) {
+    public Report readReport(final ToolConfiguration tool, final String baseDirectory, final String excludedDirectory,
+            final FilteredLog log) {
         var parser = new ParserRegistry().get(tool.getId());
 
         var displayName = StringUtils.defaultIfBlank(tool.getName(), parser.getName());
@@ -63,7 +64,7 @@ public final class FileSystemToolParser implements ToolParser {
 
         var analysisParser = parser.createParser();
         var scope = tool.getScope();
-        for (Path file : REPORT_FINDER.find(log, displayName, tool.getPattern(), directory)) {
+        for (Path file : REPORT_FINDER.find(log, displayName, tool.getPattern(), baseDirectory, excludedDirectory)) {
             var report = analysisParser.parse(new FileReaderFactory(file));
 
             if (scope == Scope.PROJECT) {
@@ -88,13 +89,14 @@ public final class FileSystemToolParser implements ToolParser {
     }
 
     @Override
-    public Node readNode(final ToolConfiguration tool, final String directory, final FilteredLog log) {
-        var parser = new edu.hm.hafner.coverage.registry.ParserRegistry().get(StringUtils.upperCase(tool.getId()),
-                ProcessingMode.IGNORE_ERRORS);
+    public Node readNode(final ToolConfiguration tool, final String baseDirectory, final String excludedDirectory,
+            final FilteredLog log) {
+        var registry = new edu.hm.hafner.coverage.registry.ParserRegistry();
+        var parser = registry.get(StringUtils.upperCase(tool.getId()), ProcessingMode.IGNORE_ERRORS);
         var scope = tool.getScope();
 
         var nodes = new ArrayList<Node>();
-        for (Path file : REPORT_FINDER.find(log, getDisplayName(tool), tool.getPattern(), directory)) {
+        for (Path file : REPORT_FINDER.find(log, getDisplayName(tool), tool.getPattern(), baseDirectory, excludedDirectory)) {
             var factory = new FileReaderFactory(file);
             try (var reader = factory.create()) {
                 var node = parser.parse(reader, file.toString(), log);

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -1,7 +1,9 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.net.URI;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -85,8 +87,45 @@ public class GradingReport {
      * @return Markdown text
      */
     public String getMarkdownSummary(final AggregatedScore score, final String title, final boolean showHeaders) {
-        return createMarkdownTotal(score, title, 2) + PARAGRAPH + getSubScoreDetails(score, showHeaders)
-                + ScoreMarkdown.LINE_BREAK;
+        return createMarkdownTotal(score, title, 2) + PARAGRAPH
+                + getSubScoreDetails(score, showHeaders) + ScoreMarkdown.LINE_BREAK
+                + getTargetDetails();
+    }
+
+    private String getTargetDetails() {
+        String commitUrl = getEnv("COMMIT_URL");
+        if (StringUtils.isBlank(commitUrl) || isInvalidUrl(commitUrl)) {
+            return StringUtils.EMPTY;
+        }
+        String runUrl = getEnv("RUN_URL");
+        if (StringUtils.isBlank(runUrl) || isInvalidUrl(runUrl)) {
+            return StringUtils.EMPTY;
+        }
+
+        return PARAGRAPH + String.format("""
+            ## :pushpin: Reference Results
+            
+            Delta reports computed against the reference results of %s in [workflow run %s](%s).
+            """, commitUrl, getUrlName(runUrl), runUrl);
+    }
+
+    private String getEnv(final String name) {
+        return StringUtils.defaultString(System.getenv(name));
+    }
+
+    private String getUrlName(final String url) {
+        return StringUtils.substringAfterLast(url, "/");
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private boolean isInvalidUrl(final String url) {
+        try {
+            new URI(url).toURL();
+            return false;
+        }
+        catch (Exception exception) {
+            return true;
+        }
     }
 
     /**
@@ -172,7 +211,8 @@ public class GradingReport {
                 + ANALYSIS_MARKDOWN.createDetails(score, showDisabled)
                 + CODE_COVERAGE_MARKDOWN.createDetails(score, showDisabled)
                 + MUTATION_COVERAGE_MARKDOWN.createDetails(score, showDisabled)
-                + METRIC_MARKDOWN.createDetails(score, showDisabled);
+                + METRIC_MARKDOWN.createDetails(score, showDisabled)
+                + getTargetDetails();
     }
 
     private String createMarkdownTotal(final AggregatedScore score, final String title, final int size) {

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -104,11 +104,9 @@ public class GradingReport {
             return StringUtils.EMPTY;
         }
 
-        return PARAGRAPH + String.format("""
-            ## :pushpin: Reference Results
-            
-            Delta reports computed against the reference results of %s in [workflow run %s](%s).
-            """, commitUrl, getUrlName(runUrl), runUrl);
+        return PARAGRAPH + "## :pushpin: Reference Results" + PARAGRAPH
+                + String.format("Delta reports computed against the reference results of %s in [workflow run %s](%s).",
+                commitUrl, getUrlName(runUrl), runUrl);
     }
 
     private String getEnv(final String name) {

--- a/src/main/java/edu/hm/hafner/grading/GradingReport.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingReport.java
@@ -3,7 +3,9 @@ package edu.hm.hafner.grading;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -123,7 +125,7 @@ public class GradingReport {
             new URI(url).toURL();
             return false;
         }
-        catch (Exception exception) {
+        catch (MalformedURLException | URISyntaxException | IllegalArgumentException exception) {
             return true;
         }
     }

--- a/src/main/java/edu/hm/hafner/grading/MetricScore.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricScore.java
@@ -13,11 +13,9 @@ import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
 
 import java.io.Serial;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -129,11 +127,11 @@ public final class MetricScore extends Score<MetricScore, MetricConfiguration> {
      */
     static class MetricScoreBuilder extends ScoreBuilder<MetricScore, MetricConfiguration> {
         MetricScoreBuilder() {
-            this(Optional.empty());
+            this(NO_DELTA_REPORTS);
         }
 
-        MetricScoreBuilder(final Optional<Path> deltaReports) {
-            super(deltaReports);
+        MetricScoreBuilder(final String deltaReportsPath) {
+            super(deltaReportsPath);
         }
 
         @Override

--- a/src/main/java/edu/hm/hafner/grading/MetricScore.java
+++ b/src/main/java/edu/hm/hafner/grading/MetricScore.java
@@ -11,6 +11,7 @@ import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.Generated;
 
 import java.io.Serial;
 import java.util.List;
@@ -120,6 +121,25 @@ public final class MetricScore extends Score<MetricScore, MetricConfiguration> {
         return getReport().getValue(metric)
                 .map(v -> "%s (%s)".formatted(v.asText(Locale.ENGLISH), metric.getAggregationType()))
                 .orElse(N_A);
+    }
+
+    @Override
+    @Generated
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        var that = (MetricScore) o;
+        return metric == that.metric;
+    }
+
+    @Override
+    @Generated
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), metric);
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/ReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/ReportFinder.java
@@ -1,15 +1,24 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 
 /**
  * Base class that finds files in the workspace.
@@ -17,40 +26,33 @@ import java.util.List;
  * @author Ullrich Hafner
  */
 class ReportFinder {
-    /**
-     * Finds reports for the specified tool.
-     *
-     * @param log
-     *         logger
-     * @param tool
-     *         the tool to find the reports for
-     *
-     * @return the paths
-     */
-    List<Path> find(final FilteredLog log, final ToolConfiguration tool) {
-        var displayName = tool.getDisplayName();
-        var pattern = tool.getPattern();
-
-        return find(log, displayName, pattern, ".");
-    }
-
-    List<Path> find(final FilteredLog log, final String displayName, final String pattern, final String directory) {
-        log.logInfo("Searching for %s results matching file name pattern %s", displayName, pattern);
-        List<Path> files = findGlob("glob:" + pattern, directory, log);
+    List<Path> find(final FilteredLog log, final String displayName, final String pattern,
+            final String directory, final String excludedDirectory) {
+        log.logInfo("Searching for %s results in folder '%s' matching file name pattern '%s'%s",
+                displayName, directory, pattern, exclude(excludedDirectory));
+        List<Path> files = findGlob("glob:" + pattern, directory, excludedDirectory, log);
 
         if (files.isEmpty()) {
-            log.logInfo("No matching report files found when using pattern '%s'! "
-                    + "Configuration error for '%s'?", pattern, displayName);
+            log.logInfo("No matching report files found in folder '%s' when using pattern '%s'! "
+                    + "Configuration error for '%s'?", directory, pattern, displayName);
         }
 
         Collections.sort(files);
         return files;
     }
 
+    private String exclude(final String excludedDirectory) {
+        if (NO_DELTA_REPORTS.equals(excludedDirectory)) {
+            return StringUtils.EMPTY;
+        }
+        return String.format(" (excluding '%s')", excludedDirectory);
+    }
+
     @VisibleForTesting
-    List<Path> findGlob(final String pattern, final String directory, final FilteredLog log) {
+    List<Path> findGlob(final String pattern, final String directory, final String excludedDirectory,
+            final FilteredLog log) {
         try {
-            var visitor = new PathMatcherFileVisitor(pattern);
+            var visitor = new PathMatcherFileVisitor(pattern, excludedDirectory);
             Files.walkFileTree(Path.of(directory), visitor);
             return visitor.getMatches();
         }
@@ -62,12 +64,15 @@ class ReportFinder {
     }
 
     private static class PathMatcherFileVisitor extends SimpleFileVisitor<Path> {
+        private static final String DEFAULT_WORK_DIRECTORY = ".";
         private final PathMatcher pathMatcher;
         private final List<Path> matches = new ArrayList<>();
+        private final String excludeDirectory;
 
-        PathMatcherFileVisitor(final String syntaxAndPattern) {
+        PathMatcherFileVisitor(final String syntaxAndPattern, final String excludeDirectory) {
             super();
 
+            this.excludeDirectory = excludeDirectory;
             try {
                 pathMatcher = FileSystems.getDefault().getPathMatcher(syntaxAndPattern);
             }
@@ -83,16 +88,25 @@ class ReportFinder {
 
         @NonNull
         @Override
-        public FileVisitResult visitFile(final Path path, @NonNull final BasicFileAttributes attrs) {
-            if (pathMatcher.matches(path)) {
+        public FileVisitResult visitFile(@NonNull final Path path, @NonNull final BasicFileAttributes attrs) {
+            if (pathMatcher.matches(path) && isNotExcluded(path)) {
                 matches.add(path);
             }
             return FileVisitResult.CONTINUE;
         }
 
+        private boolean isNotExcluded(final Path path) {
+            if (excludeDirectory.isBlank() || excludeDirectory.equals(NO_DELTA_REPORTS)) {
+                return true;
+            }
+
+            var excluded = Path.of(excludeDirectory).toAbsolutePath().normalize();
+            return !path.toAbsolutePath().normalize().startsWith(excluded);
+        }
+
         @NonNull
         @Override
-        public FileVisitResult visitFileFailed(final Path file, @NonNull final IOException exc) {
+        public FileVisitResult visitFileFailed(@NonNull final Path file, @NonNull final IOException exc) {
             return FileVisitResult.CONTINUE;
         }
     }

--- a/src/main/java/edu/hm/hafner/grading/ReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/ReportFinder.java
@@ -64,7 +64,6 @@ class ReportFinder {
     }
 
     private static class PathMatcherFileVisitor extends SimpleFileVisitor<Path> {
-        private static final String DEFAULT_WORK_DIRECTORY = ".";
         private final PathMatcher pathMatcher;
         private final List<Path> matches = new ArrayList<>();
         private final String excludeDirectory;

--- a/src/main/java/edu/hm/hafner/grading/Score.java
+++ b/src/main/java/edu/hm/hafner/grading/Score.java
@@ -27,8 +27,8 @@ import static edu.hm.hafner.grading.Configuration.*;
 public abstract class Score<S extends Score<S, C>, C extends Configuration> implements Serializable {
     @Serial
     private static final long serialVersionUID = 15L;
-    private static final int MAX_PERCENTAGE = 100;
 
+    private static final int MAX_PERCENTAGE = 100;
     private final String name;
     private final String icon;
     private final Scope scope;

--- a/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
@@ -12,10 +12,8 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A builder for {@link Score} instances.
@@ -26,12 +24,13 @@ import java.util.Optional;
  *         the type of the configuration
  */
 abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
-    private final Optional<Path> deltaReports;
+    static final String NO_DELTA_REPORTS = ".";
 
     private String name = StringUtils.EMPTY;
     private String icon = StringUtils.EMPTY;
     private String metric = StringUtils.EMPTY;
     private Scope scope = Scope.PROJECT;
+    private final String deltaReportsPath;
 
     @CheckForNull
     private C configuration;
@@ -44,8 +43,8 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
     @CheckForNull
     private Report deltaReport;
 
-    protected ScoreBuilder(final Optional<Path> deltaReports) {
-        this.deltaReports = deltaReports;
+    protected ScoreBuilder(final String deltaReportsPath) {
+        this.deltaReportsPath = deltaReportsPath;
     }
 
     /**
@@ -182,8 +181,8 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
 
     void readNode(final ToolParser factory, final ToolConfiguration tool,
             final FilteredLog log) {
-        node = factory.readNode(tool, ".", log);
-        deltaNode = deltaReports.isPresent() ? factory.readNode(tool, deltaReports.get().toString(), log) : node;
+        node = factory.readNode(tool, NO_DELTA_REPORTS, deltaReportsPath, log);
+        deltaNode = readDeltaNode(factory, tool, log);
 
         setName(tool.getName());
         setIcon(tool.getIcon());
@@ -191,14 +190,28 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
         setMetric(tool.getMetric());
     }
 
+    private Node readDeltaNode(final ToolParser factory, final ToolConfiguration tool, final FilteredLog log) {
+        if (hasDelta()) {
+            return factory.readNode(tool, deltaReportsPath, NO_DELTA_REPORTS, log);
+        }
+        return Objects.requireNonNull(node);
+    }
+
     void readReport(final ToolParser factory, final ToolConfiguration tool,
             final FilteredLog log) {
-        report = factory.readReport(tool, ".", log);
-        deltaReport = deltaReports.isPresent() ? factory.readReport(tool, deltaReports.get().toString(), log) : report;
+        report = factory.readReport(tool, NO_DELTA_REPORTS, deltaReportsPath, log);
+        deltaReport = readDeltaReport(factory, tool, log);
 
         setName(StringUtils.defaultIfBlank(tool.getName(), report.getName()));
         setIcon(tool.getIcon());
         setScope(tool.getScope());
+    }
+
+    private Report readDeltaReport(final ToolParser factory, final ToolConfiguration tool, final FilteredLog log) {
+        if (hasDelta()) {
+            return factory.readReport(tool, deltaReportsPath, NO_DELTA_REPORTS, log);
+        }
+        return Objects.requireNonNull(report);
     }
 
     Node getNode() {
@@ -218,7 +231,7 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
     }
 
     boolean hasDelta() {
-        return deltaReports.isPresent();
+        return !deltaReportsPath.equals(NO_DELTA_REPORTS);
     }
 
     @VisibleForTesting

--- a/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
@@ -202,7 +202,7 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
         report = factory.readReport(tool, NO_DELTA_REPORTS, deltaReportsPath, log);
         deltaReport = readDeltaReport(factory, tool, log);
 
-        setName(StringUtils.defaultIfBlank(tool.getName(), report.getName()));
+        setName(StringUtils.defaultIfBlank(tool.getName(), Objects.requireNonNull(report).getName()));
         setIcon(tool.getIcon());
         setScope(tool.getScope());
     }

--- a/src/main/java/edu/hm/hafner/grading/TestScore.java
+++ b/src/main/java/edu/hm/hafner/grading/TestScore.java
@@ -16,11 +16,9 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.Generated;
 
 import java.io.Serial;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -327,11 +325,11 @@ public final class TestScore extends Score<TestScore, TestConfiguration> {
      */
     static class TestScoreBuilder extends ScoreBuilder<TestScore, TestConfiguration> {
         TestScoreBuilder() {
-            this(Optional.empty());
+            this(NO_DELTA_REPORTS);
         }
 
-        TestScoreBuilder(final Optional<Path> deltaReports) {
-            super(deltaReports);
+        TestScoreBuilder(final String deltaReportsPath) {
+            super(deltaReportsPath);
         }
 
         @Override

--- a/src/main/java/edu/hm/hafner/grading/ToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/ToolParser.java
@@ -11,7 +11,7 @@ import java.util.NoSuchElementException;
  *
  * @see <a href="https://github.com/jenkinsci/analysis-model">Analysis Model</a>
  */
-public interface ToolParser {
+interface ToolParser {
     /**
      * Creates a static analysis report for the specified tool.
      *

--- a/src/main/java/edu/hm/hafner/grading/ToolParser.java
+++ b/src/main/java/edu/hm/hafner/grading/ToolParser.java
@@ -19,6 +19,8 @@ public interface ToolParser {
      *         the tool to create the report for
      * @param directory
      *         the directory to scan for reports
+     * @param excluded
+     *         the excluded files
      * @param log
      *         the logger to report the progress
      *
@@ -26,7 +28,7 @@ public interface ToolParser {
      * @throws NoSuchElementException
      *         if there is no analysis report for the specified tool
      */
-    Report readReport(ToolConfiguration tool, String directory, FilteredLog log);
+    Report readReport(ToolConfiguration tool, String directory, String excluded, FilteredLog log);
 
     /**
      * Creates a coverage report for the specified tool.
@@ -35,6 +37,8 @@ public interface ToolParser {
      *         the configuration to create the report for
      * @param directory
      *         the directory to scan for reports
+     * @param excluded
+     *         the excluded files
      * @param log
      *         the logger to report the progress
      *
@@ -42,5 +46,5 @@ public interface ToolParser {
      * @throws NoSuchElementException
      *         if there is no coverage report for the specified tool
      */
-    Node readNode(ToolConfiguration configuration, String directory, FilteredLog log);
+    Node readNode(ToolConfiguration configuration, String directory, String excluded, FilteredLog log);
 }

--- a/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AggregatedScoreTest.java
@@ -25,8 +25,8 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static edu.hm.hafner.grading.assertions.Assertions.*;
 
 @SuppressWarnings("PMD.PublicMemberInNonPublicType")
@@ -357,7 +357,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
 
         aggregation.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(GRADING_CONFIGURATION), Optional.empty());
+                AnalysisConfiguration.from(GRADING_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(aggregation)
                 .hasMaxScore(200)
@@ -378,7 +378,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
 
         aggregation.gradeTests(
                 new NodeSupplier(TestMarkdownTest::createTwoReports),
-                TestConfiguration.from(GRADING_CONFIGURATION), Optional.empty());
+                TestConfiguration.from(GRADING_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(aggregation)
                 .hasMaxScore(300)
@@ -398,7 +398,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
 
         aggregation.gradeCoverage(
                 new NodeSupplier(CoverageMarkdownTest::createTwoReports),
-                CoverageConfiguration.from(GRADING_CONFIGURATION), Optional.empty());
+                CoverageConfiguration.from(GRADING_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(aggregation)
                 .hasMaxScore(500)
@@ -419,7 +419,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
 
         aggregation.gradeMetrics(
                 new NodeSupplier(MetricMarkdownTest::createNodes),
-                MetricConfiguration.from(GRADING_CONFIGURATION), Optional.empty());
+                MetricConfiguration.from(GRADING_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(aggregation)
                 .hasMaxScore(500)
@@ -464,13 +464,13 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
         var aggregation = new AggregatedScore(logger);
         aggregation.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(QUALITY_CONFIGURATION), Optional.empty());
+                AnalysisConfiguration.from(QUALITY_CONFIGURATION), NO_DELTA_REPORTS);
         aggregation.gradeTests(
                 new NodeSupplier(TestMarkdownTest::createTwoReports),
-                TestConfiguration.from(QUALITY_CONFIGURATION), Optional.empty());
+                TestConfiguration.from(QUALITY_CONFIGURATION), NO_DELTA_REPORTS);
         aggregation.gradeCoverage(
                 new NodeSupplier(CoverageMarkdownTest::createTwoReports),
-                CoverageConfiguration.from(QUALITY_CONFIGURATION), Optional.empty());
+                CoverageConfiguration.from(QUALITY_CONFIGURATION), NO_DELTA_REPORTS);
         return aggregation;
     }
 
@@ -528,7 +528,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
 
         aggregation.gradeCoverage(
                 new NodeSupplier(AggregatedScoreTest::readCoverageReport),
-                CoverageConfiguration.from(COVERAGE_CONFIGURATION), Optional.empty());
+                CoverageConfiguration.from(COVERAGE_CONFIGURATION), NO_DELTA_REPORTS);
 
         var coveredFiles = new String[]{"ReportFactory.java",
                 "ReportFinder.java",
@@ -555,7 +555,7 @@ class AggregatedScoreTest extends SerializableTest<AggregatedScore> {
     void shouldGradeAnalysisReport() {
         var aggregation = new AggregatedScore(new FilteredLog("Test"));
 
-        aggregation.gradeAnalysis(new ReportSupplier(this::readAnalysisReport), AnalysisConfiguration.from(ANALYSIS_CONFIGURATION), Optional.empty());
+        aggregation.gradeAnalysis(new ReportSupplier(this::readAnalysisReport), AnalysisConfiguration.from(ANALYSIS_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(aggregation.getCoveredFiles(Metric.LINE)).isEmpty();
         assertThat(aggregation.getIssues()).extracting(Issue::getAbsolutePath).containsExactly(

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -7,11 +7,9 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.FilteredLog;
 
-import java.nio.file.Path;
-import java.util.Optional;
-
 import static edu.hm.hafner.grading.AnalysisMarkdown.*;
 import static edu.hm.hafner.grading.AnalysisScoreTest.*;
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -58,7 +56,7 @@ class AnalysisMarkdownTest {
                 """;
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(new ReportSupplier(t -> new Report(CHECKSTYLE, "CheckStyle")),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -87,7 +85,7 @@ class AnalysisMarkdownTest {
                 """;
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(new ReportSupplier(t -> new Report(CHECKSTYLE, "CheckStyle")),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -124,7 +122,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new ReportSupplier(t -> createSampleCheckStyleReport()),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -165,7 +163,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -203,7 +201,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -237,7 +235,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new DeltaReportSupplier(AnalysisMarkdownTest::createReferenceReports),
-                AnalysisConfiguration.from(configuration), Optional.of(Path.of(REFERENCE)));
+                AnalysisConfiguration.from(configuration), REFERENCE);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -276,7 +274,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var analysisMarkdown = new AnalysisMarkdown();
 
@@ -399,7 +397,7 @@ class AnalysisMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
         return score;
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
+++ b/src/test/java/edu/hm/hafner/grading/AutoGradingRunnerITest.java
@@ -1055,7 +1055,7 @@ class AutoGradingRunnerITest extends ResourceTest {
 
         assertThat(outputStream.toString(StandardCharsets.UTF_8))
                 .contains("Obtaining configuration from environment variable CONFIG")
-                .contains("Searching for Cyclomatic Complexity results matching file name pattern **/src/**/metrics-exception.xml",
+                .contains("Searching for Cyclomatic Complexity results in folder '.' matching file name pattern '**/src/**/metrics-exception.xml'",
                         "Cyclomatic Complexity Total: <none> [Whole Project]",
                         "=> Cyclomatic Complexity: <n/a> [Whole Project]",
                         "-> Cognitive Complexity Total: <none> [Whole Project]",

--- a/src/test/java/edu/hm/hafner/grading/CommentBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CommentBuilderTest.java
@@ -18,9 +18,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -67,7 +67,7 @@ class CommentBuilderTest {
     void shouldCreateRevApiComments() {
         var score = new AggregatedScore(new FilteredLog("Test"));
         score.gradeAnalysis(new ReportSupplier(this::readAnalysisReport),
-                AnalysisConfiguration.from(REVAPI_CONFIGURATION), Optional.empty());
+                AnalysisConfiguration.from(REVAPI_CONFIGURATION), NO_DELTA_REPORTS);
 
         var builder = createCommentBuilder();
 
@@ -291,7 +291,7 @@ class CommentBuilderTest {
         var aggregation = new AggregatedScore(new FilteredLog("Test"));
         aggregation.gradeAnalysis(new ReportSupplier(
                 t -> AnalysisMarkdownTest.createSampleCheckStyleReport()),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
         return aggregation;
     }
 
@@ -300,7 +300,7 @@ class CommentBuilderTest {
         aggregation.gradeCoverage(
                 new NodeSupplier(t ->
                         AggregatedScoreTest.readCoverageReport("mutations-dashboard.xml", CoverageParserType.PIT, "mutations-dashboard.xml")),
-                CoverageConfiguration.from(COVERAGE_CONFIGURATION), Optional.empty());
+                CoverageConfiguration.from(COVERAGE_CONFIGURATION), NO_DELTA_REPORTS);
         return aggregation;
     }
 
@@ -321,7 +321,7 @@ class CommentBuilderTest {
         var aggregation = new AggregatedScore(new FilteredLog("Test"));
         aggregation.gradeCoverage(new NodeSupplier(t ->
                         AggregatedScoreTest.readCoverageReport("mutations.xml", CoverageParserType.PIT, "mutations.xml")),
-                CoverageConfiguration.from(COVERAGE_CONFIGURATION), Optional.empty());
+                CoverageConfiguration.from(COVERAGE_CONFIGURATION), NO_DELTA_REPORTS);
 
         var builder = new StringCommentBuilder();
 
@@ -337,7 +337,7 @@ class CommentBuilderTest {
 
         var score = new AggregatedScore(new FilteredLog("Test"));
         score.gradeAnalysis(new ReportSupplier(this::readAnalysisReport),
-                AnalysisConfiguration.from(REVAPI_CONFIGURATION), Optional.empty());
+                AnalysisConfiguration.from(REVAPI_CONFIGURATION), NO_DELTA_REPORTS);
 
         builder.createAnnotations(score);
 
@@ -370,7 +370,7 @@ class CommentBuilderTest {
         var score = new AggregatedScore(new FilteredLog("Test"));
         var analysisConfigurations = AnalysisConfiguration.from(REVAPI_CONFIGURATION);
         score.gradeAnalysis(new ReportSupplier(this::readAnalysisReport),
-                analysisConfigurations, Optional.empty());
+                analysisConfigurations, NO_DELTA_REPORTS);
 
         builder.createAnnotations(score);
 

--- a/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
@@ -15,10 +15,9 @@ import edu.hm.hafner.util.FilteredLog;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static edu.hm.hafner.grading.TestMarkdownTest.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -33,7 +32,6 @@ class CoverageMarkdownTest {
     private static final String JACOCO = "jacoco";
     private static final String PIT = "pit";
     private static final String REFERENCE = "reference";
-    private static final Optional<Path> NO_DELTA_REPORTS = Optional.empty();
 
     @Test
     void shouldSkip() {
@@ -241,7 +239,7 @@ class CoverageMarkdownTest {
 
         score.gradeCoverage(
                 new DeltaNodeSupplier(CoverageMarkdownTest::createReferenceReports),
-                CoverageConfiguration.from(configuration), Optional.of(Path.of(REFERENCE)));
+                CoverageConfiguration.from(configuration), REFERENCE);
 
         var codeCoverageMarkdown = new CodeCoverageMarkdown();
 

--- a/src/test/java/edu/hm/hafner/grading/DeltaNodeSupplier.java
+++ b/src/test/java/edu/hm/hafner/grading/DeltaNodeSupplier.java
@@ -21,12 +21,12 @@ class DeltaNodeSupplier implements ToolParser {
     }
 
     @Override
-    public Report readReport(final ToolConfiguration tool, final String directory, final FilteredLog log) {
+    public Report readReport(final ToolConfiguration tool, final String directory, final String excluded, final FilteredLog log) {
         throw new UnsupportedOperationException("This parser does not support reading reports");
     }
 
     @Override
-    public Node readNode(final ToolConfiguration configuration, final String directory, final FilteredLog log) {
+    public Node readNode(final ToolConfiguration configuration, final String directory, final String excluded, final FilteredLog log) {
         return reference.apply(configuration, directory);
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/DeltaReportSupplier.java
+++ b/src/test/java/edu/hm/hafner/grading/DeltaReportSupplier.java
@@ -21,12 +21,12 @@ class DeltaReportSupplier implements ToolParser {
     }
 
     @Override
-    public Report readReport(final ToolConfiguration tool, final String directory, final FilteredLog log) {
+    public Report readReport(final ToolConfiguration tool, final String directory, final String excluded, final FilteredLog log) {
         return reference.apply(tool, directory);
     }
 
     @Override
-    public Node readNode(final ToolConfiguration configuration, final String directory, final FilteredLog log) {
+    public Node readNode(final ToolConfiguration configuration, final String directory, final String excluded, final FilteredLog log) {
         throw new UnsupportedOperationException("This parser does not support reading nodes");
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/FileSystemToolParserTest.java
+++ b/src/test/java/edu/hm/hafner/grading/FileSystemToolParserTest.java
@@ -10,11 +10,11 @@ import edu.hm.hafner.util.FilteredLog;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 
 class FileSystemToolParserTest {
@@ -132,11 +132,11 @@ class FileSystemToolParserTest {
 
         var factory = new FileSystemToolParser();
 
-        var node = factory.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = factory.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         assertFileNodes(node.getAllFileNodes());
         assertThat(log.getInfoMessages()).containsExactly(
-                "Searching for Line Coverage results matching file name pattern **/src/**/jacoco.xml",
+                "Searching for Line Coverage results in folder '.' matching file name pattern '**/src/**/jacoco.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302) [Whole Project]",
                 "-> Line Coverage Total: 10.93% [Whole Project]");
     }
@@ -146,18 +146,18 @@ class FileSystemToolParserTest {
         var log = new FilteredLog("Errors");
         var score = new AggregatedScore(log);
 
-        score.gradeCoverage(new FileSystemToolParser(), CoverageConfiguration.from(COVERAGE_CONFIGURATION), Optional.empty());
+        score.gradeCoverage(new FileSystemToolParser(), CoverageConfiguration.from(COVERAGE_CONFIGURATION), NO_DELTA_REPORTS);
 
         assertFileNodes(score.getCoveredFiles(Metric.LINE));
         assertThat(log.getInfoMessages()).contains(
-                "Searching for Line Coverage results matching file name pattern **/src/**/jacoco.xml",
+                "Searching for Line Coverage results in folder '.' matching file name pattern '**/src/**/jacoco.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: LINE: 10.93% (33/302) [Whole Project]",
                 "-> Line Coverage Total: 10.93% [Whole Project]",
-                "Searching for Branch Coverage results matching file name pattern **/src/**/jacoco.xml",
+                "Searching for Branch Coverage results in folder '.' matching file name pattern '**/src/**/jacoco.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/jacoco.xml: BRANCH: 9.52% (4/42) [Whole Project]",
                 "-> Branch Coverage Total: 9.52% [Whole Project]",
                 "=> JaCoCo Score: 20 of 100 [Whole Project]",
-                "Searching for Mutation Coverage results matching file name pattern **/src/**/mutations.xml",
+                "Searching for Mutation Coverage results in folder '.' matching file name pattern '**/src/**/mutations.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/mutations.xml: MUTATION: 7.86% (11/140) [Whole Project]",
                 "-> Mutation Coverage Total: 7.86% [Whole Project]",
                 "=> PIT Score: 16 of 100 [Whole Project]");
@@ -200,7 +200,7 @@ class FileSystemToolParserTest {
         var log = new FilteredLog("Errors");
         var score = new AggregatedScore(log);
 
-        score.gradeAnalysis(new FileSystemToolParser(), AnalysisConfiguration.from(CONFIGURATION), Optional.empty());
+        score.gradeAnalysis(new FileSystemToolParser(), AnalysisConfiguration.from(CONFIGURATION), NO_DELTA_REPORTS);
 
         assertThat(score.getIssues()).hasSize(EXPECTED_ISSUES);
         assertThat(score.getIssues()).extracting(Issue::getBaseName).containsOnly(
@@ -215,17 +215,17 @@ class FileSystemToolParserTest {
                 .map(Issue::getOriginName)
                 .hasSize(6).containsOnly("CheckStyle");
         assertThat(log.getInfoMessages()).contains(
-                "Searching for CheckStyle results matching file name pattern **/src/**/checkstyle*.xml",
+                "Searching for CheckStyle results in folder '.' matching file name pattern '**/src/**/checkstyle*.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/checkstyle.xml: 6 warnings [Whole Project]",
                 "-> CheckStyle (checkstyle): 6 warnings (error: 6) [Whole Project]",
-                "Searching for PMD results matching file name pattern **/src/**/pmd*.xml",
+                "Searching for PMD results in folder '.' matching file name pattern '**/src/**/pmd*.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/pmd.xml: 4 warnings [Whole Project]",
                 "-> PMD (pmd): 4 warnings (high: 1, normal: 2, low: 1) [Whole Project]",
                 "=> Style Score: 18 of 100 [Whole Project]",
-                "Searching for SpotBugs results matching file name pattern **/src/**/spotbugs*.xml",
+                "Searching for SpotBugs results in folder '.' matching file name pattern '**/src/**/spotbugs*.xml'",
                 "- src/test/resources/edu/hm/hafner/grading/spotbugsXml.xml: 2 bugs [Whole Project]",
                 "-> SpotBugs (spotbugs): 2 bugs (low: 2) [Whole Project]",
-                "Searching for Error Prone results matching file name pattern **/src/**/error-prone.log",
+                "Searching for Error Prone results in folder '.' matching file name pattern '**/src/**/error-prone.log'",
                 "- src/test/resources/edu/hm/hafner/grading/error-prone.log: 1 bug [Whole Project]",
                 "-> Error Prone (error-prone): 1 bug (normal: 1) [Whole Project]",
                 "=> Bugs Score: 59 of 100 [Whole Project]");
@@ -276,7 +276,7 @@ class FileSystemToolParserTest {
                 """
         );
 
-        var node = parser.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = parser.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         // Verify that modified lines were assigned to matching files
         var autoGradingAction = node.getAllFileNodes().stream()
@@ -335,7 +335,7 @@ class FileSystemToolParserTest {
                 """
         );
 
-        var node = parser.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = parser.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         // Verify that files with different path formats were matched
         var reportFactory = node.getAllFileNodes().stream()
@@ -392,7 +392,7 @@ class FileSystemToolParserTest {
                 """
         );
 
-        var node = parser.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = parser.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         // Verify that no files have modified lines assigned
         assertThat(node.getAllFileNodes())
@@ -431,7 +431,7 @@ class FileSystemToolParserTest {
                 """
         );
 
-        var node = parser.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = parser.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         // Verify that no files have modified lines (but parsing still works)
         assertThat(node.getAllFileNodes())
@@ -478,7 +478,7 @@ class FileSystemToolParserTest {
                 """
         );
 
-        var node = parser.readNode(jacoco.get(0).getTools().get(0), ".", log);
+        var node = parser.readNode(jacoco.get(0).getTools().get(0), NO_DELTA_REPORTS, NO_DELTA_REPORTS, log);
 
         // Coverage report has "edu/hm/hafner/grading/ReportFinder.java"
         // Should match with "edu/hm/hafner/grading/ReportFinder.java" from diff

--- a/src/test/java/edu/hm/hafner/grading/GradingReportITest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportITest.java
@@ -1,0 +1,94 @@
+package edu.hm.hafner.grading;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import static edu.hm.hafner.grading.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link GradingReport}.
+ *
+ * @author Ullrich Hafner
+ */
+@DefaultLocale("en")
+class GradingReportITest {
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldCreateAllQualityResultsWithLinks() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThat(results.getMarkdownSummary(score, "Summary")).contains(
+                "Delta reports computed against the reference results of ",
+                "https://github.com/uhafner/autograding-model/commit/1234567890",
+                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
+        assertThat(results.getMarkdownDetails(score, "Summary")).contains(
+                "Delta reports computed against the reference results of ",
+                "https://github.com/uhafner/autograding-model/commit/1234567890",
+                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "invalid-url")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForInvalidCommitUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "RUN_URL", value = "invalid-url")
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForInvalidRunUrls() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForEmptyCommitUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    void shouldNotCreateLinksForMissingRunUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "")
+    void shouldNotCreateLinksForEmptyRunUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    private void assertThatReferenceIsMissing(final GradingReport results, final AggregatedScore score) {
+        assertThat(results.getMarkdownSummary(score, "Summary"))
+                .doesNotContain("## :pushpin: Reference Results");
+        assertThat(results.getMarkdownDetails(score, "Summary"))
+                .doesNotContain("## :pushpin: Reference Results");
+    }
+}

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -1,13 +1,13 @@
 package edu.hm.hafner.grading;
 
-import edu.hm.hafner.util.FilteredLog;
 import org.junitpioneer.jupiter.DefaultLocale;
 
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import edu.hm.hafner.util.FilteredLog;
 
-import static edu.hm.hafner.grading.assertions.Assertions.assertThat;
-import static edu.hm.hafner.grading.assertions.Assertions.entry;
+import java.util.NoSuchElementException;
+
+import static edu.hm.hafner.grading.ScoreBuilder.*;
+import static edu.hm.hafner.grading.assertions.Assertions.*;
 
 /**
  * Tests the class {@link GradingReport}.
@@ -211,7 +211,7 @@ class GradingReportTest {
 
         aggregation.gradeAnalysis(
                 new ReportSupplier(AnalysisMarkdownTest::createTwoReports),
-                AnalysisConfiguration.from(configuration), Optional.empty());
+                AnalysisConfiguration.from(configuration), NO_DELTA_REPORTS);
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 2 static analysis configuration(s)",
                 "=> Style: 10 warnings (error: 1, high: 2, normal: 3, low: 4) [Whole Project]",
@@ -219,14 +219,14 @@ class GradingReportTest {
 
         aggregation.gradeTests(
                 new NodeSupplier(TestMarkdownTest::createTwoReports),
-                TestConfiguration.from(configuration), Optional.empty());
+                TestConfiguration.from(configuration), NO_DELTA_REPORTS);
         assertThat(logger.getInfoMessages()).contains(
                 "Processing 1 test configuration(s)",
                 "=> JUnit: 26.32% successful (14 failed, 5 passed, 3 skipped) [Whole Project]");
 
         aggregation.gradeCoverage(
                 new NodeSupplier(CoverageMarkdownTest::createTwoReports),
-                CoverageConfiguration.from(configuration), Optional.empty());
+                CoverageConfiguration.from(configuration), NO_DELTA_REPORTS);
         assertThat(String.join("\n", logger.getInfoMessages())).contains(
                 "Processing 2 coverage configuration(s)",
                 "=> JaCoCo: 70.00% (60 missed items) [Whole Project]",

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -2,7 +2,6 @@ package edu.hm.hafner.grading;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import edu.hm.hafner.util.FilteredLog;
 
@@ -180,78 +179,6 @@ class GradingReportTest {
                 "|Line Coverage|Whole Project|80",
                 "|Branch Coverage|Whole Project|60",
                 "|Mutation Coverage|Whole Project|60");
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
-    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
-    void shouldCreateAllQualityResultsWithLinks() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThat(results.getMarkdownSummary(score, "Summary")).contains(
-                "Delta reports computed against the reference results of ",
-                "https://github.com/uhafner/autograding-model/commit/1234567890",
-                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
-        assertThat(results.getMarkdownDetails(score, "Summary")).contains(
-                "Delta reports computed against the reference results of ",
-                "https://github.com/uhafner/autograding-model/commit/1234567890",
-                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "invalid-url")
-    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
-    void shouldNotCreateLinksForInvalidCommitUrl() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThatReferenceIsMissing(results, score);
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "RUN_URL", value = "invalid-url")
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
-    void shouldNotCreateLinksForInvalidRunUrls() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThatReferenceIsMissing(results, score);
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "")
-    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
-    void shouldNotCreateLinksForEmptyCommitUrl() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThatReferenceIsMissing(results, score);
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
-    void shouldNotCreateLinksForMissingRunUrl() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThatReferenceIsMissing(results, score);
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
-    @SetEnvironmentVariable(key = "RUN_URL", value = "")
-    void shouldNotCreateLinksForEmptyRunUrl() {
-        var results = new GradingReport();
-
-        var score = AggregatedScoreTest.createQualityAggregation();
-
-        assertThatReferenceIsMissing(results, score);
     }
 
     private void assertThatReferenceIsMissing(final GradingReport results, final AggregatedScore score) {

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -2,6 +2,7 @@ package edu.hm.hafner.grading;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import edu.hm.hafner.util.FilteredLog;
 
@@ -97,7 +98,7 @@ class GradingReportTest {
         var score = new AggregatedScore();
         assertThat(results.getTextSummary(score)).isEqualTo(
                 "Autograding score");
-        var disabledScores = new String[]{
+        var disabledScores = new String[] {
                 "Test Score: not enabled",
                 "Metrics Score: not enabled",
                 "Code Coverage Score: not enabled",
@@ -166,6 +167,7 @@ class GradingReportTest {
                 "Mutation Coverage (Whole Project): 60.00% — 40 survived mutations",
                 "Checkstyle (Whole Project): 10 warnings — error: 1, high: 2, normal: 3, low: 4",
                 "SpotBugs (Whole Project): 10 bugs — error: 4, high: 3, normal: 2, low: 1");
+        assertThatReferenceIsMissing(results, score);
         assertThat(results.getTextSummary(score)).isEqualTo(
                 "Autograding score");
         assertThat(results.getMarkdownDetails(score)).contains(
@@ -178,6 +180,42 @@ class GradingReportTest {
                 "|Line Coverage|Whole Project|80",
                 "|Branch Coverage|Whole Project|60",
                 "|Mutation Coverage|Whole Project|60");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldCreateAllQualityResultsWithLinks() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThat(results.getMarkdownSummary(score, "Summary")).contains(
+                "Delta reports computed against the reference results of ",
+                "https://github.com/uhafner/autograding-model/commit/1234567890",
+                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
+        assertThat(results.getMarkdownDetails(score, "Summary")).contains(
+                "Delta reports computed against the reference results of ",
+                "https://github.com/uhafner/autograding-model/commit/1234567890",
+                "in [workflow run 1](https://github.com/uhafner/autograding-model/actions/runs/1)");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "invalid-url")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForInvalidUrls() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    private void assertThatReferenceIsMissing(final GradingReport results, final AggregatedScore score) {
+        assertThat(results.getMarkdownSummary(score, "Summary"))
+                .doesNotContain("## :pushpin: Reference Results", "[Commit]", "[Run]");
+        assertThat(results.getMarkdownDetails(score, "Summary"))
+                .doesNotContain("## :pushpin: Reference Results", "[Commit]", "[Run]");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -89,6 +90,7 @@ class GradingReportTest {
             }
             """;
 
+    @Test
     void shouldCreateEmptyResults() {
         var results = new GradingReport();
 
@@ -111,29 +113,30 @@ class GradingReportTest {
                 .contains("Summary");
     }
 
+    @Test
     void shouldCreateAllGradingResults() {
         var results = new GradingReport();
 
         var score = new AggregatedScoreTest().createSerializable();
         assertThat(results.getMarkdownSummary(score, "Summary")).contains(
-                "# :mortar_board: &nbsp; Summary - 167 of 500",
-                "Integrationstests (Whole Project) - 27 of 100: 55.56% successful",
-                "Modultests (Whole Project) - 50 of 100: 0.00% successful",
-                "Line Coverage (Whole Project) - 60 of 100", "80.00% (20 missed lines)",
-                "Branch Coverage (Whole Project) - 20 of 100", "60.00% (40 missed branches)",
-                "Mutation Coverage (Whole Project) - 20 of 100: 60.00% (40 survived mutations)",
-                "Checkstyle (Whole Project) - 30 of 100: 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                "SpotBugs (Whole Project) - 0 of 100: 10 bugs (error: 4, high: 3, normal: 2, low: 1)",
+                "# :mortar_board: &nbsp; Summary - 116 of 500 (23%)",
+                "Integrationstests (Whole Project) - 56 of 100: 55.56% successful",
+                "Modultests (Whole Project) - 0 of 100: 0.00% successful — 10 failed",
+                "Line Coverage (Whole Project) - 60 of 100: 80.00% — 20 missed lines",
+                "Branch Coverage (Whole Project) - 20 of 100: 60.00% — 40 missed branches",
+                "Mutation Coverage (Whole Project) - 20 of 100: 60.00% — 40 survived mutations",
+                "Checkstyle (Whole Project) - 30 of 100: 10 warnings — error: 1, high: 2, normal: 3, low: 4",
+                "SpotBugs (Whole Project) - 0 of 100: 10 bugs — error: 4, high: 3, normal: 2, low: 1",
                 "Cyclomatic Complexity (Whole Project): 10",
                 "Cognitive Complexity (Whole Project): 100",
                 "N-Path Complexity (Whole Project): <n/a>",
                 "Non Commenting Source Statements (Whole Project): <n/a>");
 
         assertThat(results.getTextSummary(score)).isEqualTo(
-                "Autograding score - 167 of 500 (33%)");
+                "Autograding score - 116 of 500 (23%)");
         assertThat(results.getMarkdownDetails(score)).contains(
-                "Autograding score - 167 of 500 (33%)",
-                "JUnit - 77 of 100",
+                "Autograding score - 116 of 500 (23%)",
+                "JUnit - 26 of 100",
                 "JaCoCo - 40 of 100",
                 "PIT - 20 of 100",
                 "Style - 30 of 100",
@@ -144,6 +147,7 @@ class GradingReportTest {
                 "|N-Path Complexity|Whole Project|-|-|-|-|-");
     }
 
+    @Test
     void shouldCreateAllQualityResults() {
         var results = new GradingReport();
 
@@ -155,19 +159,20 @@ class GradingReportTest {
                 .doesNotContain("JUnit Tests", "Code Coverage", "Style");
 
         assertThat(results.getMarkdownSummary(score, "Summary")).contains(
-                "Integrationstests (Whole Project): 55.56% successful", "4 failed", "5 passed", "3 skipped",
-                "Modultests (Whole Project): 0.00% successful", "10 failed",
-                "Line Coverage (Whole Project): 80.00% (20 missed lines)",
-                "Branch Coverage (Whole Project): 60.00% (40 missed branches)",
-                "Mutation Coverage (Whole Project): 60.00% (40 survived mutations)",
-                "Checkstyle (Whole Project): 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                "SpotBugs (Whole Project): 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                "Integrationstests (Whole Project): ❌&nbsp;unstable — 4 failed, 5 passed, 3 skipped",
+                "Modultests (Whole Project): ❌&nbsp;unstable — 10 failed",
+                "Line Coverage (Whole Project): 80.00% — 20 missed lines",
+                "Branch Coverage (Whole Project): 60.00% — 40 missed branches",
+                "Mutation Coverage (Whole Project): 60.00% — 40 survived mutations",
+                "Checkstyle (Whole Project): 10 warnings — error: 1, high: 2, normal: 3, low: 4",
+                "SpotBugs (Whole Project): 10 bugs — error: 4, high: 3, normal: 2, low: 1");
         assertThat(results.getTextSummary(score)).isEqualTo(
                 "Autograding score");
         assertThat(results.getMarkdownDetails(score)).contains(
                 "Autograding score",
-                "|Integrationstests|Whole Project|12|5|3|4|:x:",
-                "|Modultests|Whole Project|10|0|0|10|:x:",
+                "|Integrationstests|Whole Project|5|3|4|:x:",
+                "|Modultests|Whole Project|0|0|10|:x:\n"
+                        + "|**Total**|**-**|**-**|**5**|**3**|**14**|:x:",
                 "|Checkstyle|Whole Project|10",
                 "|SpotBugs|Whole Project|10",
                 "|Line Coverage|Whole Project|80",
@@ -175,16 +180,18 @@ class GradingReportTest {
                 "|Mutation Coverage|Whole Project|60");
     }
 
+    @Test
     void shouldCreateErrorReport() {
         var results = new GradingReport();
 
         var score = AggregatedScoreTest.createGradingAggregation();
         assertThat(results.getMarkdownErrors(score, new NoSuchElementException("This is an error")))
-                .contains("# Partial score: 167/500",
+                .contains("# Partial score: 116/500",
                         "The grading has been aborted due to an error.",
                         "java.util.NoSuchElementException: This is an error");
     }
 
+    @Test
     void shouldCreateAnalysisResults() {
         var results = new GradingReport();
 
@@ -201,6 +208,7 @@ class GradingReportTest {
                 "Bugs - 0 of 100");
     }
 
+    @Test
     void shouldSkipScores() {
         var configuration = NO_SCORE_CONFIGURATION;
 
@@ -246,12 +254,13 @@ class GradingReportTest {
 
         assertThat(results.getMarkdownSummary(aggregation, "Summary")).contains(
                 "## :sunny: &nbsp; Summary",
-                "Integrationstests (Whole Project): 55.56% successful", "4 failed", "5 passed", "3 skipped",
-                "Modultests (Whole Project): 0.00% successful", "10 failed",
-                "Branch Coverage (Whole Project): 60.00% (40 missed branches)",
-                "Mutation Coverage (Whole Project): 60.00% (40 survived mutations)",
-                "Checkstyle (Whole Project): 10 warnings (error: 1, high: 2, normal: 3, low: 4)",
-                "SpotBugs (Whole Project): 10 bugs (error: 4, high: 3, normal: 2, low: 1)");
+                "Integrationstests (Whole Project): ❌&nbsp;unstable", "4 failed", "5 passed", "3 skipped",
+                "Modultests (Whole Project): ❌&nbsp;unstable", "10 failed",
+                "Line Coverage (Whole Project): 80.00% — 20 missed lines",
+                "Branch Coverage (Whole Project): 60.00% — 40 missed branches",
+                "Mutation Coverage (Whole Project): 60.00% — 40 survived mutations",
+                "Checkstyle (Whole Project): 10 warnings — error: 1, high: 2, normal: 3, low: 4",
+                "SpotBugs (Whole Project): 10 bugs — error: 4, high: 3, normal: 2, low: 1");
         assertThat(results.getTextSummary(aggregation)).isEqualTo(
                 "Autograding score");
         assertThat(results.getTextSummary(aggregation, "Quality Summary")).isEqualTo(

--- a/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
+++ b/src/test/java/edu/hm/hafner/grading/GradingReportTest.java
@@ -203,7 +203,50 @@ class GradingReportTest {
     @Test
     @SetEnvironmentVariable(key = "COMMIT_URL", value = "invalid-url")
     @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
-    void shouldNotCreateLinksForInvalidUrls() {
+    void shouldNotCreateLinksForInvalidCommitUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "RUN_URL", value = "invalid-url")
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForInvalidRunUrls() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "https://github.com/uhafner/autograding-model/actions/runs/1")
+    void shouldNotCreateLinksForEmptyCommitUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    void shouldNotCreateLinksForMissingRunUrl() {
+        var results = new GradingReport();
+
+        var score = AggregatedScoreTest.createQualityAggregation();
+
+        assertThatReferenceIsMissing(results, score);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "COMMIT_URL", value = "https://github.com/uhafner/autograding-model/commit/1234567890")
+    @SetEnvironmentVariable(key = "RUN_URL", value = "")
+    void shouldNotCreateLinksForEmptyRunUrl() {
         var results = new GradingReport();
 
         var score = AggregatedScoreTest.createQualityAggregation();
@@ -213,9 +256,9 @@ class GradingReportTest {
 
     private void assertThatReferenceIsMissing(final GradingReport results, final AggregatedScore score) {
         assertThat(results.getMarkdownSummary(score, "Summary"))
-                .doesNotContain("## :pushpin: Reference Results", "[Commit]", "[Run]");
+                .doesNotContain("## :pushpin: Reference Results");
         assertThat(results.getMarkdownDetails(score, "Summary"))
-                .doesNotContain("## :pushpin: Reference Results", "[Commit]", "[Run]");
+                .doesNotContain("## :pushpin: Reference Results");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/MetricMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/MetricMarkdownTest.java
@@ -10,8 +10,7 @@ import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
 import edu.hm.hafner.util.FilteredLog;
 
-import java.util.Optional;
-
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -58,7 +57,7 @@ class MetricMarkdownTest {
         method.addValue(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
         score.gradeMetrics(
                 new NodeSupplier(t -> root),
-                MetricConfiguration.from(configuration), Optional.empty());
+                MetricConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var metricMarkdown = new MetricMarkdown();
 
@@ -97,7 +96,7 @@ class MetricMarkdownTest {
 
         score.gradeMetrics(
                 new NodeSupplier(MetricMarkdownTest::createNodes),
-                MetricConfiguration.from(configuration), Optional.empty());
+                MetricConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var metricMarkdown = new MetricMarkdown();
 
@@ -144,7 +143,7 @@ class MetricMarkdownTest {
 
         score.gradeMetrics(
                 new NodeSupplier(MetricMarkdownTest::createNodes),
-                MetricConfiguration.from(configuration), Optional.empty());
+                MetricConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var metricMarkdown = new MetricMarkdown();
 
@@ -193,7 +192,7 @@ class MetricMarkdownTest {
 
         score.gradeMetrics(
                 new NodeSupplier(t -> new ModuleNode("Root")),
-                MetricConfiguration.from(configuration), Optional.empty());
+                MetricConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var metricMarkdown = new MetricMarkdown();
 
@@ -275,7 +274,7 @@ class MetricMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeMetrics(
                 new NodeSupplier(MetricMarkdownTest::getReadCoverageReport),
-                MetricConfiguration.from(configuration), Optional.empty());
+                MetricConfiguration.from(configuration), NO_DELTA_REPORTS);
 
         var markdown = new MetricMarkdown();
 

--- a/src/test/java/edu/hm/hafner/grading/MetricScoreTest.java
+++ b/src/test/java/edu/hm/hafner/grading/MetricScoreTest.java
@@ -1,0 +1,130 @@
+package edu.hm.hafner.grading;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.ModuleNode;
+import edu.hm.hafner.coverage.Node;
+import edu.hm.hafner.coverage.Value;
+import edu.hm.hafner.grading.MetricScore.MetricScoreBuilder;
+
+import java.util.List;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+import static edu.hm.hafner.grading.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link MetricScore}.
+ *
+ * @author Ullrich Hafner
+ */
+class MetricScoreTest {
+    private static final String NAME = "Metric Name";
+
+    @Test
+    void shouldCreateInstanceAndGetProperties() {
+        var configuration = createConfiguration();
+        var report = createReport(Metric.CYCLOMATIC_COMPLEXITY, 10, "root");
+        var score = new MetricScoreBuilder()
+                .setName(NAME)
+                .setConfiguration(configuration)
+                .create(report, Metric.CYCLOMATIC_COMPLEXITY);
+
+        assertThat(score)
+                .hasName(NAME)
+                .hasConfiguration(configuration)
+                .hasMetric(Metric.CYCLOMATIC_COMPLEXITY)
+                .hasReport(report)
+                .hasMaxScore(0)
+                .hasImpact(0);
+
+        assertThat(score.getMetricValue()).isEqualTo(new Value(Metric.CYCLOMATIC_COMPLEXITY, 10));
+        assertThat(score.getMetricValueAsString()).isEqualTo("10");
+        assertThat(score.getMetricTagName()).isEqualTo("cyclomatic-complexity");
+    }
+
+    @Test
+    void shouldHandleMissingMetricValue() {
+        var configuration = createConfiguration();
+        var report = new ModuleNode("empty");
+        var score = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .create(report, Metric.CYCLOMATIC_COMPLEXITY);
+
+        assertThat(score.getMetricValue()).isEqualTo(Value.nullObject(Metric.CYCLOMATIC_COMPLEXITY));
+        assertThat(score.getMetricValueAsString()).isEqualTo("<n/a>");
+    }
+
+    @Test
+    void shouldAggregateDifferentMetrics() {
+        var configuration = createConfiguration();
+
+        var red = createReport(Metric.CYCLOMATIC_COMPLEXITY, 10, "red");
+        var redScore = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .create(red, Metric.CYCLOMATIC_COMPLEXITY);
+
+        var blue = createReport(Metric.LOC, 100, "report2");
+        var blueScore = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .create(blue, Metric.LOC);
+
+        var aggregated = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .aggregate(List.of(redScore, blueScore));
+
+        assertThat(aggregated.getMetric()).isEqualTo(Metric.CONTAINER);
+        assertThat(aggregated.getMetricValueAsString()).isEqualTo("<n/a>");
+    }
+
+    @Test
+    void shouldAggregateSameMetrics() {
+        var configuration = createConfiguration();
+
+        var report1 = createReport(Metric.CYCLOMATIC_COMPLEXITY, 10, "report1");
+        var score1 = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .create(report1, Metric.CYCLOMATIC_COMPLEXITY);
+
+        var report2 = createReport(Metric.CYCLOMATIC_COMPLEXITY, 20, "report2");
+        var score2 = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .create(report2, Metric.CYCLOMATIC_COMPLEXITY);
+
+        var aggregated = new MetricScoreBuilder()
+                .setConfiguration(configuration)
+                .aggregate(List.of(score1, score2));
+
+        assertThat(aggregated.getMetric()).isEqualTo(Metric.CYCLOMATIC_COMPLEXITY);
+        assertThat(aggregated.getMetricValue()).isEqualTo(new Value(Metric.CYCLOMATIC_COMPLEXITY, 30));
+    }
+
+    @Test
+    void shouldAdhereToEquals() {
+        EqualsVerifier.forClass(MetricScore.class)
+                .withRedefinedSuperclass()
+                .withIgnoredFields("report")
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+
+    private MetricConfiguration createConfiguration() {
+        return MetricConfiguration.from("""
+                {
+                  "metrics": [{
+                    "tools": [{
+                      "id": "metrics",
+                      "pattern": "target/*.xml"
+                    }]
+                  }]
+                }
+                """).get(0);
+    }
+
+    private Node createReport(final Metric metric, final int value, final String name) {
+        var root = new ModuleNode(name);
+        root.addValue(new Value(metric, value));
+        return root;
+    }
+}

--- a/src/test/java/edu/hm/hafner/grading/NodeSupplier.java
+++ b/src/test/java/edu/hm/hafner/grading/NodeSupplier.java
@@ -19,12 +19,12 @@ class NodeSupplier implements ToolParser {
     }
 
     @Override
-    public Report readReport(final ToolConfiguration tool, final String directory, final FilteredLog log) {
+    public Report readReport(final ToolConfiguration tool, final String directory, final String excluded, final FilteredLog log) {
         throw new UnsupportedOperationException("This parser does not support reading reports");
     }
 
     @Override
-    public Node readNode(final ToolConfiguration configuration, final String directory, final FilteredLog log) {
+    public Node readNode(final ToolConfiguration configuration, final String directory, final String excluded, final FilteredLog log) {
         return reference.apply(configuration);
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
@@ -1,5 +1,6 @@
 package edu.hm.hafner.grading;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -25,9 +26,21 @@ class ReportFinderTest {
         assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/delta", NO_DELTA_REPORTS, LOG)).hasSize(1);
 
         assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/",
+                StringUtils.EMPTY, LOG)).hasSize(19);
+        assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/",
                 "src/test/resources/edu/hm/hafner/grading/delta", LOG)).hasSize(18);
         assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/",
                 "src/test/resources/", LOG)).isEmpty();
+    }
+
+    @Test
+    void shouldHandleWrongPatterns() {
+        var finder = new ReportFinder();
+
+        assertThatThrownBy(() -> finder.findGlob("undefined:.*\\.xml", NO_DELTA_REPORTS, NO_DELTA_REPORTS, LOG))
+                .hasMessageContaining("Syntax 'undefined' not recognized");
+        assertThatThrownBy(() -> finder.findGlob("regex:[", NO_DELTA_REPORTS, NO_DELTA_REPORTS, LOG))
+                .hasMessageContaining("Pattern not valid for FileSystem.getPathMatcher: regex:[");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
+++ b/src/test/java/edu/hm/hafner/grading/ReportFinderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 
 class ReportFinderTest {
@@ -14,18 +15,26 @@ class ReportFinderTest {
     void shouldFindTestReports() {
         var finder = new ReportFinder();
 
-        assertThat(finder.findGlob("glob:**/grading/TEST*.xml", "src/test/resources/", LOG)).hasSize(3);
-        assertThat(finder.findGlob("glob:src/test/resources/**/grading/*edu*.xml", "src/test/resources/", LOG)).hasSize(2);
-        assertThat(finder.findGlob("glob:src/**/*.html", "src/test/resources/", LOG)).isEmpty();
+        assertThat(finder.findGlob("glob:**/grading/TEST*.xml", "src/test/resources/", NO_DELTA_REPORTS, LOG)).hasSize(3);
+        assertThat(finder.findGlob("glob:src/test/resources/**/grading/*edu*.xml", "src/test/resources/", NO_DELTA_REPORTS, LOG)).hasSize(2);
+        assertThat(finder.findGlob("glob:src/**/*.html", "src/test/resources/", NO_DELTA_REPORTS, LOG)).isEmpty();
 
-        assertThat(finder.findGlob("glob:**/*.xml", "src/java/", LOG)).isEmpty();
+        assertThat(finder.findGlob("glob:**/*.xml", "src/java/", NO_DELTA_REPORTS, LOG)).isEmpty();
+
+        assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/", NO_DELTA_REPORTS, LOG)).hasSize(19);
+        assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/delta", NO_DELTA_REPORTS, LOG)).hasSize(1);
+
+        assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/",
+                "src/test/resources/edu/hm/hafner/grading/delta", LOG)).hasSize(18);
+        assertThat(finder.findGlob("glob:**/*.xml", "src/test/resources/edu/hm/hafner/grading/",
+                "src/test/resources/", LOG)).isEmpty();
     }
 
     @Test
     void shouldFindSources() {
         var finder = new ReportFinder();
         var pathUtil = new PathUtil();
-        assertThat(finder.findGlob("regex:.*Markdown.*\\.java", "src/main/java/", LOG))
+        assertThat(finder.findGlob("regex:.*Markdown.*\\.java", "src/main/java/", NO_DELTA_REPORTS, LOG))
                 .map(pathUtil::getRelativePath)
                 .containsExactlyInAnyOrder("src/main/java/edu/hm/hafner/grading/CoverageMarkdown.java",
                         "src/main/java/edu/hm/hafner/grading/CodeCoverageMarkdown.java",

--- a/src/test/java/edu/hm/hafner/grading/ReportSupplier.java
+++ b/src/test/java/edu/hm/hafner/grading/ReportSupplier.java
@@ -19,12 +19,12 @@ class ReportSupplier implements ToolParser {
     }
 
     @Override
-    public Report readReport(final ToolConfiguration tool, final String directory, final FilteredLog log) {
+    public Report readReport(final ToolConfiguration tool, final String directory, final String excluded, final FilteredLog log) {
         return reference.apply(tool);
     }
 
     @Override
-    public Node readNode(final ToolConfiguration configuration, final String directory, final FilteredLog log) {
+    public Node readNode(final ToolConfiguration configuration, final String directory, final String excluded, final FilteredLog log) {
         throw new UnsupportedOperationException("This parser does not support reading nodes");
     }
 }

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -10,9 +10,7 @@ import edu.hm.hafner.coverage.Rate;
 import edu.hm.hafner.coverage.TestCase.TestCaseBuilder;
 import edu.hm.hafner.util.FilteredLog;
 
-import java.nio.file.Path;
-import java.util.Optional;
-
+import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static edu.hm.hafner.grading.TestMarkdown.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -26,7 +24,6 @@ class TestMarkdownTest {
     private static final FilteredLog LOG = new FilteredLog("Test");
     private static final int TOO_MANY_FAILURES = 400;
     private static final String REFERENCE = "reference";
-    private static final Optional<Path> NO_DELTA_REPORTS = Optional.empty();
 
     @Test
     void shouldSkipWhenThereAreNoScores() {
@@ -142,7 +139,7 @@ class TestMarkdownTest {
         var score = new AggregatedScore(LOG);
 
         var factory = new FileSystemToolParser();
-        var node = factory.readNode(configurations.getFirst().getTools().getFirst(), ".", new FilteredLog("Errors"));
+        var node = factory.readNode(configurations.getFirst().getTools().getFirst(), NO_DELTA_REPORTS, NO_DELTA_REPORTS, new FilteredLog("Errors"));
 
         score.gradeTests(
                 new NodeSupplier(t -> node),
@@ -341,7 +338,7 @@ class TestMarkdownTest {
         var score = new AggregatedScore(LOG);
         score.gradeTests(
                 new DeltaNodeSupplier(TestMarkdownTest::createReferenceReports),
-                TestConfiguration.from(configuration), Optional.of(Path.of(REFERENCE)));
+                TestConfiguration.from(configuration), REFERENCE);
 
         var testMarkdown = new TestMarkdown();
 


### PR DESCRIPTION
Otherwise the reference results are taken into account for the PR results as well. This will produce a lot of duplicate items.