### PR TITLE
Enable delta computation based on scope

### DIFF
--- a/src/main/java/edu/hm/hafner/grading/Score.java
+++ b/src/main/java/edu/hm/hafner/grading/Score.java
@@ -79,7 +79,6 @@ public abstract class Score<S extends Score<S, C>, C extends Configuration> impl
      * Returns whether this score has a delta. A delta is the difference between the current score and a reference
      * score, e.g., from a previous build. Note that delta computation is only available in the project scope.
      *
-     *
      * @return {@code true} if this score has a delta, {@code false} otherwise
      */
     public final boolean hasDelta() {

--- a/src/main/java/edu/hm/hafner/grading/Score.java
+++ b/src/main/java/edu/hm/hafner/grading/Score.java
@@ -77,12 +77,13 @@ public abstract class Score<S extends Score<S, C>, C extends Configuration> impl
 
     /**
      * Returns whether this score has a delta. A delta is the difference between the current score and a reference
-     * score, e.g., from a previous build.
+     * score, e.g., from a previous build. Note that delta computation is only available in the project scope.
+     *
      *
      * @return {@code true} if this score has a delta, {@code false} otherwise
      */
     public final boolean hasDelta() {
-        return delta;
+        return delta && getScope() == Scope.PROJECT;
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
+++ b/src/main/java/edu/hm/hafner/grading/ScoreBuilder.java
@@ -181,12 +181,12 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
 
     void readNode(final ToolParser factory, final ToolConfiguration tool,
             final FilteredLog log) {
+        setScope(tool.getScope());
         node = factory.readNode(tool, NO_DELTA_REPORTS, deltaReportsPath, log);
         deltaNode = readDeltaNode(factory, tool, log);
 
         setName(tool.getName());
         setIcon(tool.getIcon());
-        setScope(tool.getScope());
         setMetric(tool.getMetric());
     }
 
@@ -199,12 +199,12 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
 
     void readReport(final ToolParser factory, final ToolConfiguration tool,
             final FilteredLog log) {
+        setScope(tool.getScope());
         report = factory.readReport(tool, NO_DELTA_REPORTS, deltaReportsPath, log);
         deltaReport = readDeltaReport(factory, tool, log);
 
         setName(StringUtils.defaultIfBlank(tool.getName(), Objects.requireNonNull(report).getName()));
         setIcon(tool.getIcon());
-        setScope(tool.getScope());
     }
 
     private Report readDeltaReport(final ToolParser factory, final ToolConfiguration tool, final FilteredLog log) {
@@ -231,7 +231,7 @@ abstract class ScoreBuilder<S extends Score<S, C>, C extends Configuration> {
     }
 
     boolean hasDelta() {
-        return !deltaReportsPath.equals(NO_DELTA_REPORTS);
+        return !deltaReportsPath.equals(NO_DELTA_REPORTS) && getScope() == Scope.PROJECT;
     }
 
     @VisibleForTesting

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static edu.hm.hafner.grading.AnalysisMarkdown.*;
 import static edu.hm.hafner.grading.AnalysisScoreTest.*;
@@ -220,6 +221,8 @@ class AnalysisMarkdownTest {
 
     @ParameterizedTest(name = "{index} => Show delta column for {0}")
     @EnumSource(Scope.class)
+    @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
+            justification = "The string is used as JSON configuration")
     void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {

--- a/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/AnalysisMarkdownTest.java
@@ -2,6 +2,8 @@ package edu.hm.hafner.grading;
 
 import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
@@ -216,14 +218,16 @@ class AnalysisMarkdownTest {
                 .doesNotContain("Impact");
     }
 
-    @Test
-    void shouldShowDelta() {
+    @ParameterizedTest(name = "{index} => Show delta column for {0}")
+    @EnumSource(Scope.class)
+    void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {
                   "analysis": [{
                     "tools": [
                       {
                         "id": "checkstyle",
+                        "scope": "%s",
                         "name": "CheckStyle",
                         "pattern": "target/checkstyle.xml"
                       }
@@ -231,7 +235,8 @@ class AnalysisMarkdownTest {
                     "name": "CheckStyle"
                   }]
                 }
-                """;
+                """.formatted(scope.name());
+
         var score = new AggregatedScore(LOG);
         score.gradeAnalysis(
                 new DeltaReportSupplier(AnalysisMarkdownTest::createReferenceReports),
@@ -240,16 +245,23 @@ class AnalysisMarkdownTest {
         var analysisMarkdown = new AnalysisMarkdown();
 
         assertThat(analysisMarkdown.createSummary(score)).contains(
-                "CheckStyle (Whole Project)",
-                "10 warnings",
-                "(+1)",
-                "error: 1, high: 2, normal: 3, low: 4");
+                "CheckStyle", "10 warnings", "error: 1, high: 2, normal: 3, low: 4",
+                scope.getDisplayName());
         assertThat(analysisMarkdown.createSummary(score, true))
-                .contains("CheckStyle", "10 warnings", "(+1)", "error: 1, high: 2, normal: 3, low: 4")
+                .contains("CheckStyle", "10 warnings", "error: 1, high: 2, normal: 3, low: 4")
                 .doesNotContain("(Whole Project)");
         assertThat(analysisMarkdown.createDetails(score))
-                .contains("CheckStyle",  "|CheckStyle|Whole Project|10", "(+1)")
+                .contains(" CheckStyle",  "|CheckStyle|", "|10", "|%s|".formatted(scope.getDisplayName()))
                 .doesNotContain("Impact");
+
+        if (scope == Scope.PROJECT) {
+            assertThat(analysisMarkdown.createSummary(score)).contains("(+1)");
+            assertThat(analysisMarkdown.createDetails(score)).contains("(+1)");
+        }
+        else {
+            assertThat(analysisMarkdown.createSummary(score)).doesNotContain("(+1)");
+            assertThat(analysisMarkdown.createDetails(score)).doesNotContain("(+1)");
+        }
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
@@ -13,6 +13,7 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.registry.ParserRegistry;
 import edu.hm.hafner.coverage.registry.ParserRegistry.CoverageParserType;
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -217,6 +218,8 @@ class CoverageMarkdownTest {
 
     @ParameterizedTest(name = "{index} => Show delta column for {0}")
     @EnumSource(Scope.class)
+    @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
+            justification = "The string is used as JSON configuration")
     void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {

--- a/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/CoverageMarkdownTest.java
@@ -1,6 +1,8 @@
 package edu.hm.hafner.grading;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import edu.hm.hafner.coverage.ContainerNode;
 import edu.hm.hafner.coverage.Coverage.CoverageBuilder;
@@ -213,20 +215,23 @@ class CoverageMarkdownTest {
         verifyEmptyMutationScore(score);
     }
 
-    @Test
-    void shouldShowDelta() {
+    @ParameterizedTest(name = "{index} => Show delta column for {0}")
+    @EnumSource(Scope.class)
+    void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {
                   "coverage": {
                       "tools": [
                           {
                             "id": "jacoco",
+                            "scope": "%s",
                             "name": "Line Coverage",
                             "metric": "line",
                             "pattern": "target/jacoco.xml"
                           },
                           {
                             "id": "jacoco",
+                            "scope": "%s",
                             "name": "Branch Coverage",
                             "metric": "branch",
                             "pattern": "target/jacoco.xml"
@@ -234,7 +239,7 @@ class CoverageMarkdownTest {
                         ]
                   }
                 }
-                """;
+                """.formatted(scope.name(), scope.name());
         var score = new AggregatedScore(LOG);
 
         score.gradeCoverage(
@@ -245,13 +250,33 @@ class CoverageMarkdownTest {
 
         assertThat(clean(codeCoverageMarkdown.createDetails(score)))
                 .contains("Code Coverage",
-                        "|Line Coverage|Whole Project|80.00 (-10.00)",
-                        "|Branch Coverage|Whole Project|60.00 (+10.00)",
-                        "|**Total**|**-**|**70.00 (±0)**")
+                        "|Line Coverage|", "|80.00",
+                        "|Branch Coverage|", "|60.00",
+                        "|**Total**|**-**|**70.00",
+                        scope.getDisplayName())
                 .doesNotContain("Impact");
         assertThat(clean(codeCoverageMarkdown.createSummary(score))).contains(
-                "Line Coverage (Whole Project): 80.00% (-10.00)", "20 missed lines",
-                "Branch Coverage (Whole Project): 60.00% (+10.00)", "40 missed branches");
+                "Line Coverage", "80.00%", "20 missed lines",
+                "Branch Coverage", "60.00%", "40 missed branches",
+                scope.getDisplayName());
+
+        if (scope == Scope.PROJECT) {
+            assertThat(codeCoverageMarkdown.createDetails(score)).contains("(-10.00)");
+            assertThat(codeCoverageMarkdown.createDetails(score)).contains("(+10.00)");
+            assertThat(codeCoverageMarkdown.createDetails(score)).contains("(±0)");
+
+            assertThat(codeCoverageMarkdown.createSummary(score)).contains("(-10.00)");
+            assertThat(codeCoverageMarkdown.createSummary(score)).contains("(+10.00)");
+        }
+        else {
+            assertThat(codeCoverageMarkdown.createDetails(score)).doesNotContain("(-10.00)");
+            assertThat(codeCoverageMarkdown.createDetails(score)).doesNotContain("(+10.00)");
+            assertThat(codeCoverageMarkdown.createDetails(score)).doesNotContain("(±0)");
+
+            assertThat(codeCoverageMarkdown.createSummary(score)).doesNotContain("(-10.00)");
+            assertThat(codeCoverageMarkdown.createSummary(score)).doesNotContain("(+10.00)");
+        }
+
         verifyEmptyMutationScore(score);
     }
 

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -11,6 +11,7 @@ import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Rate;
 import edu.hm.hafner.coverage.TestCase.TestCaseBuilder;
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static edu.hm.hafner.grading.ScoreBuilder.*;
 import static edu.hm.hafner.grading.TestMarkdown.*;
@@ -318,6 +319,8 @@ class TestMarkdownTest {
 
     @ParameterizedTest(name = "{index} => Show delta column for {0}")
     @EnumSource(Scope.class)
+    @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
+            justification = "The string is used as JSON configuration")
     void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {

--- a/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
+++ b/src/test/java/edu/hm/hafner/grading/TestMarkdownTest.java
@@ -1,6 +1,8 @@
 package edu.hm.hafner.grading;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import edu.hm.hafner.coverage.ClassNode;
 import edu.hm.hafner.coverage.Metric;
@@ -314,19 +316,22 @@ class TestMarkdownTest {
                 "Modultests (Whole Project):", "10 failed");
     }
 
-    @Test
-    void shouldShowDelta() {
+    @ParameterizedTest(name = "{index} => Show delta column for {0}")
+    @EnumSource(Scope.class)
+    void shouldShowDelta(final Scope scope) {
         var configuration = """
                 {
                   "tests": [{
                     "tools": [
                       {
                         "id": "junit",
+                        "scope": "%s",
                         "name": "Integrationstests",
                         "pattern": "target/i-junit.xml"
                       },
                       {
                         "id": "junit",
+                        "scope": "%s",
                         "name": "Modultests",
                         "pattern": "target/u-junit.xml"
                       }
@@ -334,7 +339,7 @@ class TestMarkdownTest {
                     "name": "JUnit"
                   }]
                 }
-                """;
+                """.formatted(scope.name(), scope.name());
         var score = new AggregatedScore(LOG);
         score.gradeTests(
                 new DeltaNodeSupplier(TestMarkdownTest::createReferenceReports),
@@ -342,20 +347,43 @@ class TestMarkdownTest {
 
         var testMarkdown = new TestMarkdown();
 
-        assertThat(clean(getDetails(testMarkdown, score)))
-                .contains("JUnit",
-                        "|Integrationstests|Whole Project|4 (-1)|3 (±0)|5 (+1)|:x:",
-                        "|Modultests|Whole Project|5 (+5)|2 (+2)|10 (±0)|:x:",
-                        "**Total**|**-**|**-**|**9 (+4)**|**5 (+2)**|**15 (+1)**|:x:",
-                        "### Skipped Tests",
-                        "- test-class-skipped-0#test-skipped-0",
-                        "- test-class-skipped-1#test-skipped-1",
-                        "- test-class-skipped-2#test-skipped-2")
-                .doesNotContain(IMPACT_CONFIGURATION)
-                .doesNotContain("Impact");
-        assertThat(clean(testMarkdown.createSummary(score))).contains(
-                "Integrationstests (Whole Project):", "❌", "unstable", "5 failed (+1), 4 passed (-1), 3 skipped (±0)",
-                "Modultests (Whole Project)", "❌", "unstable", "10 failed (±0), 5 passed (+5), 2 skipped (+2)");
+        if (scope == Scope.PROJECT) {
+            assertThat(clean(getDetails(testMarkdown, score)))
+                    .contains("JUnit",
+                            "|Integrationstests|", "|4 (-1)|3 (±0)|5 (+1)|:x:",
+                            "|Modultests|", "|5 (+5)|2 (+2)|10 (±0)|:x:",
+                            "**Total**|**-**|**-**|**9 (+4)**|**5 (+2)**|**15 (+1)**|:x:",
+                            "### Skipped Tests",
+                            "- test-class-skipped-0#test-skipped-0",
+                            "- test-class-skipped-1#test-skipped-1",
+                            "- test-class-skipped-2#test-skipped-2",
+                            scope.getDisplayName())
+                    .doesNotContain(IMPACT_CONFIGURATION)
+                    .doesNotContain("Impact");
+            assertThat(clean(testMarkdown.createSummary(score))).contains(
+                    "Integrationstests (Whole Project):", "❌", "unstable",
+                    "5 failed (+1), 4 passed (-1), 3 skipped (±0)",
+                    "Modultests (Whole Project)", "❌", "unstable", "10 failed (±0), 5 passed (+5), 2 skipped (+2)");
+        }
+        else {
+            assertThat(clean(getDetails(testMarkdown, score)))
+                    .contains("JUnit",
+                            "|Integrationstests|", "|4|3|5|:x:",
+                            "|Modultests|", "|5|2|10|:x:",
+                            "**Total**|**-**|**-**|**9**|**5**|**15**|:x:",
+                            "### Skipped Tests",
+                            "- test-class-skipped-0#test-skipped-0",
+                            "- test-class-skipped-1#test-skipped-1",
+                            "- test-class-skipped-2#test-skipped-2",
+                            scope.getDisplayName())
+                    .doesNotContain(IMPACT_CONFIGURATION)
+                    .doesNotContain("Impact");
+            assertThat(clean(testMarkdown.createSummary(score))).contains(
+                    "Integrationstests", "❌", "unstable",
+                    "5 failed, 4 passed, 3 skipped",
+                    "Modultests", "❌", "unstable", "10 failed, 5 passed, 2 skipped",
+                    scope.getDisplayName());
+        }
     }
 
     static String clean(final String coloredLine) {


### PR DESCRIPTION
It makes no sense to use the modified code scope in combination with the delta computation. The delta computation should solely be based on the absolute difference to the last main build.

Fixes #628.